### PR TITLE
Modo oscuro en la página

### DIFF
--- a/src/components/asignaturas/detalle/AsignaturaDetailPage.tsx
+++ b/src/components/asignaturas/detalle/AsignaturaDetailPage.tsx
@@ -224,7 +224,7 @@ function DatosGenerales({
     rows: Array<CriterioEvaluacionRow>,
   ) => {
     await updateAsignatura.mutateAsync({
-      asignaturaId: asignaturaId as any,
+      asignaturaId: asignaturaId,
       patch: {
         criterios_de_evaluacion: rows,
       } as any,
@@ -581,15 +581,15 @@ function InfoCard({
   }, [type, evalRows])
 
   return (
-    <div ref={containerRef as any}>
+    <div ref={containerRef}>
       <Card
         className={
-          'hover:border-border overflow-hidden transition-all ' +
+          'hover:border-border overflow-hidden pt-0 transition-all ' +
           (isHighlighted ? 'ring-primary/40 ring-2' : '')
         }
       >
         <TooltipProvider>
-          <CardHeader className="bg-muted/50 border-b px-5 py-3">
+          <CardHeader className="bg-muted/50 border-b px-5 pt-5 [.border-b]:pb-2">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Tooltip>

--- a/src/components/asignaturas/detalle/ContenidoTematico.tsx
+++ b/src/components/asignaturas/detalle/ContenidoTematico.tsx
@@ -730,10 +730,10 @@ export function ContenidoTematico() {
     <div className="animate-in fade-in space-y-6 pb-8 duration-500">
       <div className="group/list relative flex items-center justify-between border-b pb-4">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900">
+          <h2 className="text-foreground text-2xl font-bold tracking-tight">
             Contenido Temático
           </h2>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="text-muted-foreground mt-1 text-sm">
             {unidades.length} unidades • {totalHoras} horas estimadas totales
           </p>
         </div>
@@ -768,16 +768,16 @@ export function ContenidoTematico() {
                     onInsert={() => insertUnidadAt(index + 1)}
                   />
 
-                  <Card className="overflow-hidden border-slate-200 shadow-sm">
+                  <Card className="border-border overflow-hidden shadow-sm">
                     <Collapsible
                       open={expandedUnits.has(unidad.id)}
                       onOpenChange={() => toggleUnit(unidad.id)}
                     >
-                      <CardHeader className="border-b border-slate-100 bg-slate-50/50 py-3">
+                      <CardHeader className="border-border/60 bg-muted/20 border-b py-3">
                         <div className="flex items-center gap-3">
                           <span
-                            ref={handleRef as any}
-                            className="inline-flex cursor-grab touch-none items-center text-slate-300"
+                            ref={handleRef}
+                            className="text-muted-foreground/50 inline-flex cursor-grab touch-none items-center"
                             aria-label="Reordenar unidad"
                           >
                             <GripVertical className="h-4 w-4" />
@@ -795,7 +795,7 @@ export function ContenidoTematico() {
                               )}
                             </Button>
                           </CollapsibleTrigger>
-                          <Badge className="bg-blue-600 font-mono">
+                          <Badge className="font-mono">
                             Unidad {unidad.numero}
                           </Badge>
 
@@ -826,11 +826,11 @@ export function ContenidoTematico() {
                                   e.currentTarget.blur()
                                 }
                               }}
-                              className="h-8 max-w-md bg-white"
+                              className="bg-background h-8 max-w-md"
                             />
                           ) : (
                             <CardTitle
-                              className="cursor-pointer text-base font-semibold transition-colors hover:text-blue-600"
+                              className="hover:text-primary cursor-pointer text-base font-semibold transition-colors"
                               onClick={() => beginEditUnit(unidad.id)}
                             >
                               {unidad.nombre}
@@ -838,7 +838,7 @@ export function ContenidoTematico() {
                           )}
 
                           <div className="ml-auto flex items-center gap-3">
-                            <span className="flex cursor-default items-center gap-1 text-xs font-medium text-slate-400">
+                            <span className="text-muted-foreground flex cursor-default items-center gap-1 text-xs font-medium">
                               <Clock className="h-3 w-3" />{' '}
                               {unidad.temas.reduce(
                                 (sum, t) => sum + (t.horasEstimadas || 0),
@@ -849,7 +849,7 @@ export function ContenidoTematico() {
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="h-8 w-8 cursor-pointer text-slate-400 hover:text-red-500"
+                              className="text-muted-foreground hover:text-destructive h-8 w-8 cursor-pointer"
                               onClick={() =>
                                 setDeleteDialog({
                                   type: 'unidad',
@@ -863,8 +863,8 @@ export function ContenidoTematico() {
                         </div>
                       </CardHeader>
                       <CollapsibleContent>
-                        <CardContent className="bg-white pt-4">
-                          <div className="ml-10 space-y-1 border-l-2 border-slate-50 pl-4">
+                        <CardContent className="bg-background pt-4">
+                          <div className="border-border/40 ml-10 space-y-1 border-l-2 pl-4">
                             <DragDropProvider
                               onDragEnd={(event) =>
                                 handleTemaReorderEnd(unidad.id, event)
@@ -917,7 +917,7 @@ export function ContenidoTematico() {
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="mt-2 w-full cursor-pointer justify-start text-blue-600 hover:bg-blue-50 hover:text-blue-700"
+                              className="text-primary hover:bg-accent/50 hover:text-primary mt-2 w-full cursor-pointer justify-start"
                               onClick={() => addTema(unidad.id)}
                             >
                               <Plus className="mr-2 h-3 w-3" /> Añadir subtema
@@ -979,17 +979,19 @@ function TemaRow({
     <div
       className={cn(
         'group flex items-center gap-3 rounded-md p-2 transition-all',
-        isEditing ? 'bg-blue-50 ring-1 ring-blue-100' : 'hover:bg-slate-50',
+        isEditing ? 'bg-accent/40 ring-ring/30 ring-1' : 'hover:bg-muted/30',
       )}
     >
       <span
-        ref={handleRef as any}
-        className="inline-flex cursor-grab touch-none items-center text-slate-300"
+        ref={handleRef}
+        className="text-muted-foreground/50 inline-flex cursor-grab touch-none items-center"
         aria-label="Reordenar tema"
       >
         <GripVertical className="h-4 w-4" />
       </span>
-      <span className="w-4 font-mono text-xs text-slate-400">{index}.</span>
+      <span className="text-muted-foreground w-4 font-mono text-xs">
+        {index}.
+      </span>
       {isEditing ? (
         <div
           className="animate-in slide-in-from-left-2 flex flex-1 items-center gap-2"
@@ -1000,7 +1002,7 @@ function TemaRow({
             ref={onNombreInputRef}
             value={draftNombre}
             onChange={(e) => onDraftNombreChange(e.target.value)}
-            className="h-8 flex-1 bg-white"
+            className="bg-background h-8 flex-1"
             placeholder="Nombre"
           />
           <Input
@@ -1010,7 +1012,7 @@ function TemaRow({
             max={200}
             step={0.5}
             onChange={(e) => onDraftHorasChange(e.target.value)}
-            className="h-8 w-16 bg-white"
+            className="bg-background h-8 w-16"
           />
         </div>
       ) : (
@@ -1023,7 +1025,7 @@ function TemaRow({
               onBeginEdit()
             }}
           >
-            <p className="text-sm font-medium text-slate-700">{tema.nombre}</p>
+            <p className="text-foreground text-sm font-medium">{tema.nombre}</p>
             <Badge variant="secondary" className="text-[10px] opacity-60">
               {tema.horasEstimadas}h
             </Badge>
@@ -1032,7 +1034,7 @@ function TemaRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7 cursor-pointer text-slate-400 hover:text-blue-600"
+              className="text-muted-foreground hover:text-primary h-7 w-7 cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation()
                 onBeginEdit()
@@ -1043,7 +1045,7 @@ function TemaRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7 cursor-pointer text-slate-400 hover:text-red-500"
+              className="text-muted-foreground hover:text-destructive h-7 w-7 cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation()
                 onDelete()
@@ -1089,7 +1091,7 @@ function DeleteConfirmDialog({
           <AlertDialogCancel>Cancelar</AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
-            className="bg-red-600 text-white hover:bg-red-700"
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
             Eliminar
           </AlertDialogAction>

--- a/src/components/asignaturas/detalle/DocumentoSEPTab.tsx
+++ b/src/components/asignaturas/detalle/DocumentoSEPTab.tsx
@@ -119,7 +119,7 @@ export function DocumentoSEPTab({
         ) : pdfUrl ? (
           <iframe
             src={`${pdfUrl}#toolbar=0`}
-            className="h-full w-full border-none"
+            className="h-full w-full border-none dark:hue-rotate-180 dark:invert"
             title="Documento SEP"
           />
         ) : (

--- a/src/components/asignaturas/detalle/HistorialTab.tsx
+++ b/src/components/asignaturas/detalle/HistorialTab.tsx
@@ -32,26 +32,25 @@ import {
 import { useSubjectHistorial } from '@/data/hooks/useSubjects'
 import { cn } from '@/lib/utils'
 
-const tipoConfig: Record<string, { label: string; icon: any; color: string }> =
-  {
-    datos: { label: 'Datos generales', icon: FileText, color: 'text-info' },
-    contenido: {
-      label: 'Contenido temático',
-      icon: List,
-      color: 'text-accent',
-    },
-    bibliografia: {
-      label: 'Bibliografía',
-      icon: BookMarked,
-      color: 'text-success',
-    },
-    ia: { label: 'IA', icon: Sparkles, color: 'text-amber-500' },
-    documento: {
-      label: 'Documento SEP',
-      icon: FileCheck,
-      color: 'text-primary',
-    },
-  }
+const tipoConfig = {
+  datos: { label: 'Datos generales', icon: FileText, color: 'text-info' },
+  contenido: {
+    label: 'Contenido temático',
+    icon: List,
+    color: 'text-accent',
+  },
+  bibliografia: {
+    label: 'Bibliografía',
+    icon: BookMarked,
+    color: 'text-success',
+  },
+  ia: { label: 'IA', icon: Sparkles, color: 'text-amber-500' },
+  documento: {
+    label: 'Documento SEP',
+    icon: FileCheck,
+    color: 'text-primary',
+  },
+} as const
 
 export function HistorialTab() {
   const { asignaturaId } = useParams({
@@ -87,7 +86,7 @@ export function HistorialTab() {
           {value.map((item, index) => (
             <div
               key={index}
-              className="rounded-lg border bg-white/50 p-3 shadow-sm"
+              className="bg-muted/20 border-border/60 rounded-lg border p-3 shadow-sm"
             >
               <RenderValue value={item} />
             </div>
@@ -102,13 +101,13 @@ export function HistorialTab() {
         <div className="grid gap-2">
           {Object.entries(value).map(([key, val]) => (
             <div key={key} className="flex flex-col">
-              <span className="text-[10px] font-bold tracking-wider text-slate-400 uppercase">
+              <span className="text-muted-foreground text-[10px] font-bold tracking-wider uppercase">
                 {key.replace(/_/g, ' ')}
               </span>
-              <div className="text-sm text-slate-700">
+              <div className="text-foreground text-sm">
                 {/* Llamada recursiva para manejar lo que haya dentro del valor */}
                 {typeof val === 'object' ? (
-                  <div className="mt-1 border-l-2 border-slate-100 pl-2">
+                  <div className="border-border/60 mt-1 border-l-2 pl-2">
                     <RenderValue value={val} />
                   </div>
                 ) : (
@@ -126,27 +125,25 @@ export function HistorialTab() {
   }
 
   const historialTransformado = useMemo(() => {
-  if (!rawData) return []
+    if (!rawData) return []
 
-  return rawData.map((item: any) => {
-    const campo = item.campo ?? 'desconocido'
+    return rawData.map((item: any) => {
+      const campo = item.campo ?? 'desconocido'
 
-    return {
-      id: item.id,
-      tipo: campo === 'contenido_tematico' ? 'contenido' : 'datos',
-      descripcion: `Se actualizó el campo ${campo.replace(/_/g, ' ')}`,
-      fecha: item.cambiado_en
-        ? parseISO(item.cambiado_en)
-        : new Date(),
-      usuario: item.fuente === 'HUMANO' ? 'Usuario Staff' : 'Sistema IA',
-      detalles: {
-        campo,
-        valor_anterior: item.valor_anterior || 'Sin datos previos',
-        valor_nuevo: item.valor_nuevo,
-      },
-    }
-  })
-}, [rawData])
+      return {
+        id: item.id,
+        tipo: campo === 'contenido_tematico' ? 'contenido' : 'datos',
+        descripcion: `Se actualizó el campo ${campo.replace(/_/g, ' ')}`,
+        fecha: item.cambiado_en ? parseISO(item.cambiado_en) : new Date(),
+        usuario: item.fuente === 'HUMANO' ? 'Usuario Staff' : 'Sistema IA',
+        detalles: {
+          campo,
+          valor_anterior: item.valor_anterior || 'Sin datos previos',
+          valor_nuevo: item.valor_nuevo,
+        },
+      }
+    })
+  }, [rawData])
 
   const openCompareModal = (cambio: any) => {
     setSelectedChange(cambio)
@@ -166,13 +163,13 @@ export function HistorialTab() {
   )
 
   const groupedHistorial = filteredHistorial.reduce(
-    (groups, cambio) => {
+    (groups: Record<string, Array<any> | undefined>, cambio) => {
       const dateKey = format(cambio.fecha, 'yyyy-MM-dd')
       if (!groups[dateKey]) groups[dateKey] = []
       groups[dateKey].push(cambio)
       return groups
     },
-    {} as Record<string, Array<any>>,
+    {},
   )
 
   const sortedDates = Object.keys(groupedHistorial).sort((a, b) =>
@@ -244,14 +241,20 @@ export function HistorialTab() {
               </div>
 
               <div className="border-border ml-4 space-y-4 border-l-2 pl-6">
-                {groupedHistorial[dateKey].map((cambio) => {
-                  const config = tipoConfig[cambio.tipo] || tipoConfig.datos
+                {(groupedHistorial[dateKey] ?? []).map((cambio) => {
+                  type TipoConfigItem =
+                    (typeof tipoConfig)[keyof typeof tipoConfig]
+
+                  const config =
+                    (tipoConfig as Partial<Record<string, TipoConfigItem>>)[
+                      cambio.tipo
+                    ] ?? tipoConfig.datos
                   const Icon = config.icon
                   return (
                     <div key={cambio.id} className="relative">
                       <div
                         className={cn(
-                          'border-background absolute -left-[31px] h-4 w-4 rounded-full border-2',
+                          'border-background absolute -left-7.75 h-4 w-4 rounded-full border-2',
                           `bg-current ${config.color}`,
                         )}
                       />
@@ -311,9 +314,9 @@ export function HistorialTab() {
       {/* MODAL DE COMPARACIÓN */}
       <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
         <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden">
-          <DialogHeader className="flex-shrink-0">
+          <DialogHeader className="shrink-0">
             <DialogTitle className="flex items-center gap-2 text-xl">
-              <History className="h-5 w-5 text-blue-500" />
+              <History className="text-primary h-5 w-5" />
               Comparación de cambios
             </DialogTitle>
             {/* ... info de usuario y fecha */}
@@ -323,13 +326,13 @@ export function HistorialTab() {
             <div className="grid h-full grid-cols-2 gap-6">
               {/* Lado Antes */}
               <div className="flex flex-col space-y-3">
-                <div className="sticky top-0 z-10 flex items-center gap-2 bg-white pb-2">
-                  <div className="h-2 w-2 rounded-full bg-red-400" />
-                  <span className="text-xs font-bold text-slate-500 uppercase">
+                <div className="bg-background sticky top-0 z-10 flex items-center gap-2 pb-2">
+                  <div className="bg-destructive h-2 w-2 rounded-full" />
+                  <span className="text-muted-foreground text-xs font-bold uppercase">
                     Versión Anterior
                   </span>
                 </div>
-                <div className="flex-1 rounded-xl border border-red-100 bg-red-50/30 p-4">
+                <div className="border-destructive/20 bg-destructive/5 flex-1 rounded-xl border p-4">
                   <RenderValue
                     value={selectedChange?.detalles.valor_anterior}
                   />
@@ -338,22 +341,24 @@ export function HistorialTab() {
 
               {/* Lado Después */}
               <div className="flex flex-col space-y-3">
-                <div className="sticky top-0 z-10 flex items-center gap-2 bg-white pb-2">
-                  <div className="h-2 w-2 rounded-full bg-emerald-400" />
-                  <span className="text-xs font-bold text-slate-500 uppercase">
+                <div className="bg-background sticky top-0 z-10 flex items-center gap-2 pb-2">
+                  <div className="bg-primary h-2 w-2 rounded-full" />
+                  <span className="text-muted-foreground text-xs font-bold uppercase">
                     Nueva Versión
                   </span>
                 </div>
-                <div className="flex-1 rounded-xl border border-emerald-100 bg-emerald-50/40 p-4">
+                <div className="border-primary/20 bg-primary/5 flex-1 rounded-xl border p-4">
                   <RenderValue value={selectedChange?.detalles.valor_nuevo} />
                 </div>
               </div>
             </div>
           </div>
 
-          <div className="mt-4 flex flex-shrink-0 items-center justify-center gap-2 rounded-lg border border-slate-100 bg-slate-50 p-3 text-xs text-slate-500">
+          <div className="bg-muted/20 border-border text-muted-foreground mt-4 flex shrink-0 items-center justify-center gap-2 rounded-lg border p-3 text-xs">
             Campo modificado:{' '}
-            <Badge variant="secondary">{selectedChange?.detalles.campo ?? 'Sin campo'}</Badge>
+            <Badge variant="secondary">
+              {selectedChange?.detalles.campo ?? 'Sin campo'}
+            </Badge>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/wizard/WizardLayout.tsx
+++ b/src/components/wizard/WizardLayout.tsx
@@ -24,7 +24,7 @@ export function WizardLayout({
           e.preventDefault()
         }}
       >
-        <div className="z-10 flex-none border-b bg-white">
+        <div className="bg-background z-10 flex-none border-b">
           <CardHeader className="flex flex-row items-center justify-between gap-4 p-6 pb-3">
             <CardTitle>{title}</CardTitle>
             <button
@@ -39,12 +39,14 @@ export function WizardLayout({
           {headerSlot ? <div className="px-6 pb-3">{headerSlot}</div> : null}
         </div>
 
-        <div className="flex-1 overflow-y-auto bg-gray-50/30 px-4 py-3 xl:px-6">
+        <div className="bg-muted/20 flex-1 overflow-y-auto px-4 py-3 xl:px-6">
           {children}
         </div>
 
         {footerSlot ? (
-          <div className="flex-none border-t bg-white p-6">{footerSlot}</div>
+          <div className="bg-background flex-none border-t p-6">
+            {footerSlot}
+          </div>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/src/components/wizard/WizardResponsiveHeader.tsx
+++ b/src/components/wizard/WizardResponsiveHeader.tsx
@@ -32,27 +32,25 @@ export function WizardResponsiveHeader({
         <div className="flex items-center gap-5">
           <CircularProgress current={currentIndex} total={totalSteps} />
           <div className="flex flex-col justify-center">
-            <h2 className="text-lg font-bold text-slate-900">
+            <h2 className="text-foreground text-lg font-bold">
               <StepWithTooltip
                 title={resolveTitle(methods.current)}
                 desc={methods.current.description}
               />
             </h2>
             {hasNextStep && nextStep ? (
-              <p className="text-sm text-slate-400">
+              <p className="text-muted-foreground text-sm">
                 Siguiente: {resolveTitle(nextStep)}
               </p>
             ) : (
-              <p className="text-sm font-medium text-green-500">
-                ¡Último paso!
-              </p>
+              <p className="text-primary text-sm font-medium">¡Último paso!</p>
             )}
           </div>
         </div>
       </div>
 
       <div className="hidden sm:block">
-        <wizard.Stepper.Navigation className="border-border/60 rounded-xl border bg-slate-50 p-2">
+        <wizard.Stepper.Navigation className="border-border/60 bg-muted/30 rounded-xl border p-2">
           {visibleSteps.map((step: any, visibleIdx: number) => (
             <wizard.Stepper.Step
               key={step.id}

--- a/src/features/bibliografia/nueva/NuevaBibliografiaModalContainer.tsx
+++ b/src/features/bibliografia/nueva/NuevaBibliografiaModalContainer.tsx
@@ -261,9 +261,7 @@ export function BookSelectionAccordion({
                       <div className="flex items-center gap-2">
                         <span className="font-semibold">{opt.title}</span>
                         {opt.badgeText ? (
-                          <Badge className="bg-green-600 hover:bg-green-700">
-                            {opt.badgeText}
-                          </Badge>
+                          <Badge variant="secondary">{opt.badgeText}</Badge>
                         ) : null}
                       </div>
                       {opt.subtitle ? (
@@ -1756,7 +1754,7 @@ function SugerenciasStep({
                 key={s.id}
                 aria-checked={selected}
                 className={cn(
-                  'border-border hover:border-primary/30 hover:bg-accent/50 m-0.5 flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-aria-checked:border-blue-600 has-aria-checked:bg-blue-50 dark:has-aria-checked:border-blue-900 dark:has-aria-checked:bg-blue-950',
+                  'border-border hover:border-primary/30 hover:bg-accent/50 has-aria-checked:border-primary has-aria-checked:bg-accent/30 m-0.5 flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors',
                 )}
               >
                 <Checkbox
@@ -1790,7 +1788,7 @@ function SugerenciasStep({
                       target="_blank"
                       rel="noreferrer"
                       className={cn(
-                        'text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs underline transition-colors visited:text-purple-500',
+                        'text-muted-foreground hover:text-primary visited:text-primary/80 inline-flex items-center gap-1 text-xs underline transition-colors',
                         !browserHref && 'invisible',
                       )}
                     >
@@ -1916,17 +1914,11 @@ const BibliotecaStep = forwardRef<BibliotecaStepHandle, BibliotecaStepProps>(
 
             const badge =
               badgeState === 'por_revisar' ? (
-                <Badge className="bg-yellow-500 text-black hover:bg-yellow-500">
-                  Por revisar
-                </Badge>
+                <Badge variant="secondary">Por revisar</Badge>
               ) : badgeState === 'sustituido' ? (
-                <Badge className="bg-green-600 text-white hover:bg-green-700">
-                  Sustituido
-                </Badge>
+                <Badge variant="outline">Sustituido</Badge>
               ) : (
-                <Badge className="bg-blue-600 text-white hover:bg-blue-700">
-                  Mantenido
-                </Badge>
+                <Badge>Mantenido</Badge>
               )
 
             const radioValue =
@@ -2159,7 +2151,7 @@ function DatosBasicosManualStep({
           {refs.map((r) => (
             <div
               key={r.id}
-              className="flex items-start justify-between gap-3 rounded-lg border bg-white p-3"
+              className="border-border/60 bg-background flex items-start justify-between gap-3 rounded-lg border p-3"
             >
               <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-medium">{r.title}</div>

--- a/src/routes/planes/$planId/_detalle/asignaturas.tsx
+++ b/src/routes/planes/$planId/_detalle/asignaturas.tsx
@@ -35,29 +35,35 @@ import { usePlanAsignaturas, usePlanLineas } from '@/data'
 // --- Configuración de Estilos ---
 const statusConfig: Record<
   AsignaturaStatus,
-  { label: string; className: string }
+  {
+    label: string
+    variant: 'default' | 'secondary' | 'destructive' | 'outline'
+    className?: string
+  }
 > = {
   generando: {
     label: 'Generando',
-    className:
-      'bg-slate-100 text-slate-600 animate-pulse [animation-duration:2s]',
+    variant: 'secondary',
+    className: 'animate-pulse [animation-duration:2s]',
   },
-  borrador: { label: 'Borrador', className: 'bg-slate-100 text-slate-600' },
-  revisada: { label: 'Revisada', className: 'bg-amber-100 text-amber-700' },
-  aprobada: { label: 'Aprobada', className: 'bg-emerald-100 text-emerald-700' },
-  fallida: { label: 'Fallida', className: 'bg-red-100 text-red-700' },
+  borrador: { label: 'Borrador', variant: 'secondary' },
+  revisada: { label: 'Revisada', variant: 'outline' },
+  aprobada: { label: 'Aprobada', variant: 'default' },
+  fallida: { label: 'Fallida', variant: 'destructive' },
 }
 
-const tipoConfig: Record<TipoAsignatura, { label: string; className: string }> =
+const tipoConfig: Record<
+  TipoAsignatura,
   {
-    OBLIGATORIA: {
-      label: 'Obligatoria',
-      className: 'bg-blue-100 text-blue-700',
-    },
-    OPTATIVA: { label: 'Optativa', className: 'bg-purple-100 text-purple-700' },
-    TRONCAL: { label: 'Troncal', className: 'bg-slate-100 text-slate-700' },
-    OTRA: { label: 'Otra', className: 'bg-slate-100 text-slate-700' },
+    label: string
+    variant: 'default' | 'secondary' | 'destructive' | 'outline'
   }
+> = {
+  OBLIGATORIA: { label: 'Obligatoria', variant: 'default' },
+  OPTATIVA: { label: 'Optativa', variant: 'secondary' },
+  TRONCAL: { label: 'Troncal', variant: 'outline' },
+  OTRA: { label: 'Otra', variant: 'outline' },
+}
 
 // --- Mapeadores de API ---
 const mapAsignaturas = (
@@ -161,14 +167,14 @@ function AsignaturasPage() {
       </div>
 
       {/* Barra de Filtros Avanzada */}
-      <div className="flex flex-wrap items-center gap-3 rounded-xl border bg-slate-50 p-4">
+      <div className="bg-muted/30 border-border flex flex-wrap items-center gap-3 rounded-xl border p-4">
         <div className="relative min-w-60 flex-1">
           <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
           <Input
             placeholder="Buscar por nombre o clave..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="bg-white pl-9"
+            className="bg-background pl-9"
           />
         </div>
 
@@ -176,7 +182,7 @@ function AsignaturasPage() {
           <Filter className="text-muted-foreground mr-1 h-4 w-4" />
 
           <Select value={filterTipo} onValueChange={setFilterTipo}>
-            <SelectTrigger className="w-35 bg-white">
+            <SelectTrigger className="bg-background w-35">
               <SelectValue placeholder="Tipo" />
             </SelectTrigger>
             <SelectContent>
@@ -187,7 +193,7 @@ function AsignaturasPage() {
           </Select>
 
           <Select value={filterEstado} onValueChange={setFilterEstado}>
-            <SelectTrigger className="w-35 bg-white">
+            <SelectTrigger className="bg-background w-35">
               <SelectValue placeholder="Estado" />
             </SelectTrigger>
             <SelectContent>
@@ -199,7 +205,7 @@ function AsignaturasPage() {
           </Select>
 
           <Select value={filterLinea} onValueChange={setFilterLinea}>
-            <SelectTrigger className="w-45 bg-white">
+            <SelectTrigger className="bg-background w-45">
               <SelectValue placeholder="Línea" />
             </SelectTrigger>
             <SelectContent>
@@ -215,10 +221,10 @@ function AsignaturasPage() {
       </div>
 
       {/* Tabla Pro */}
-      <div className="overflow-hidden rounded-xl border bg-white shadow-sm">
+      <div className="bg-background overflow-hidden rounded-xl border shadow-sm">
         <Table>
           <TableHeader>
-            <TableRow className="bg-slate-50/50">
+            <TableRow className="bg-muted/20">
               <TableHead className="w-30 px-6 py-4">Clave</TableHead>
               <TableHead className="px-6 py-4">Nombre</TableHead>
               <TableHead className="px-6 py-4 text-center">Créditos</TableHead>
@@ -250,7 +256,7 @@ function AsignaturasPage() {
               filteredAsignaturas.map((asignatura) => (
                 <TableRow
                   key={asignatura.id}
-                  className="group cursor-pointer transition-colors hover:bg-slate-50/80"
+                  className="group hover:bg-muted/30 cursor-pointer transition-colors"
                   onClick={() =>
                     navigate({
                       to: '/planes/$planId/asignaturas/$asignaturaId',
@@ -265,10 +271,10 @@ function AsignaturasPage() {
                     })
                   }
                 >
-                  <TableCell className="px-6 py-4 font-mono text-xs font-bold text-slate-400">
+                  <TableCell className="text-muted-foreground px-6 py-4 font-mono text-xs font-bold">
                     {asignatura.clave}
                   </TableCell>
-                  <TableCell className="px-6 py-4 font-semibold text-slate-700">
+                  <TableCell className="text-foreground px-6 py-4 font-semibold">
                     {asignatura.nombre}
                   </TableCell>
                   <TableCell className="px-6 py-4 text-center font-medium">
@@ -280,31 +286,31 @@ function AsignaturasPage() {
                         Ciclo {asignatura.ciclo}
                       </Badge>
                     ) : (
-                      <span className="text-slate-300">—</span>
+                      <span className="text-muted-foreground/60">—</span>
                     )}
                   </TableCell>
-                  <TableCell className="px-6 py-4 text-sm text-slate-600">
+                  <TableCell className="text-muted-foreground px-6 py-4 text-sm">
                     {getLineaNombre(asignatura.lineaCurricularId)}
                   </TableCell>
                   <TableCell className="px-6 py-4">
                     <Badge
-                      variant="outline"
-                      className={`capitalize shadow-sm ${tipoConfig[asignatura.tipo].className}`}
+                      variant={tipoConfig[asignatura.tipo].variant}
+                      className="capitalize shadow-sm"
                     >
                       {tipoConfig[asignatura.tipo].label}
                     </Badge>
                   </TableCell>
                   <TableCell className="px-6 py-4">
                     <Badge
-                      variant="outline"
-                      className={`capitalize shadow-sm ${statusConfig[asignatura.estado]?.className}`}
+                      variant={statusConfig[asignatura.estado].variant}
+                      className={`capitalize shadow-sm ${statusConfig[asignatura.estado].className ?? ''}`}
                     >
-                      {statusConfig[asignatura.estado]?.label}
+                      {statusConfig[asignatura.estado].label}
                     </Badge>
                   </TableCell>
                   <TableCell className="px-6 py-4">
                     <div className="opacity-0 transition-opacity group-hover:opacity-100">
-                      <ChevronRight className="h-5 w-5 text-slate-400" />
+                      <ChevronRight className="text-muted-foreground h-5 w-5" />
                     </div>
                   </TableCell>
                 </TableRow>

--- a/src/routes/planes/$planId/_detalle/documento.tsx
+++ b/src/routes/planes/$planId/_detalle/documento.tsx
@@ -102,11 +102,11 @@ function RouteComponent() {
     }
   }
   return (
-    <div className="flex min-h-screen flex-col gap-6 bg-slate-50/30">
+    <div className="bg-background flex min-h-screen flex-col gap-6">
       {/* HEADER DE ACCIONES */}
       <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
         <div>
-          <h1 className="text-xl font-bold text-slate-800">
+          <h1 className="text-foreground text-xl font-bold">
             Documento del Plan
           </h1>
           <p className="text-muted-foreground text-sm">
@@ -157,9 +157,9 @@ function RouteComponent() {
 
       {/* CONTENEDOR DEL DOCUMENTO (Visor) */}
       {/* CONTENEDOR DEL VISOR REAL */}
-      <Card className="overflow-hidden border-slate-200 shadow-sm">
-        <div className="flex items-center justify-between border-b bg-slate-100/50 p-2 px-4">
-          <div className="flex items-center gap-2 text-xs font-medium text-slate-500">
+      <Card className="border-border overflow-hidden shadow-sm">
+        <div className="border-border bg-muted/20 flex items-center justify-between border-b p-2 px-4">
+          <div className="text-muted-foreground flex items-center gap-2 text-xs font-medium">
             <FileText size={14} /> Preview_Documento.pdf
           </div>
           {pdfUrl && (
@@ -174,21 +174,22 @@ function RouteComponent() {
           )}
         </div>
 
-        <CardContent className="flex min-h-200 justify-center bg-slate-500 p-0">
+        <CardContent className="bg-muted flex min-h-200 justify-center p-0">
           {isLoading ? (
-            <div className="flex flex-col items-center justify-center gap-4 text-white">
-              <RefreshCcw size={40} className="animate-spin opacity-50" />
+            <div className="text-muted-foreground flex flex-col items-center justify-center gap-4">
+              <RefreshCcw size={40} className="animate-spin opacity-60" />
               <p className="animate-pulse">Generando vista previa del PDF...</p>
             </div>
           ) : pdfUrl ? (
             /* 3. VISOR DE PDF REAL */
             <iframe
               src={`${pdfUrl}#toolbar=0&navpanes=0`}
-              className="h-250 w-full max-w-250 border-none shadow-2xl"
+              /* Agregadas las clases dark:invert dark:hue-rotate-180 */
+              className="h-250 w-full max-w-250 border-none shadow-2xl dark:hue-rotate-180 dark:invert"
               title="PDF Preview"
             />
           ) : (
-            <div className="flex items-center justify-center p-20 text-slate-400">
+            <div className="text-muted-foreground flex items-center justify-center p-20">
               No se pudo cargar la vista previa.
             </div>
           )}
@@ -227,14 +228,16 @@ function StatusCard({
   value: string
 }) {
   return (
-    <Card className="border-slate-200 bg-white">
+    <Card className="border-border bg-card">
       <CardContent className="flex items-center gap-4 p-4">
-        <div className="rounded-full border bg-slate-50 p-2">{icon}</div>
+        <div className="border-border bg-muted/30 rounded-full border p-2">
+          {icon}
+        </div>
         <div>
-          <p className="text-[10px] font-bold tracking-tight text-slate-400 uppercase">
+          <p className="text-muted-foreground text-[10px] font-bold tracking-tight uppercase">
             {label}
           </p>
-          <p className="text-sm font-semibold text-slate-700">{value}</p>
+          <p className="text-foreground text-sm font-semibold">{value}</p>
         </div>
       </CardContent>
     </Card>

--- a/src/routes/planes/$planId/_detalle/flujo.tsx
+++ b/src/routes/planes/$planId/_detalle/flujo.tsx
@@ -124,12 +124,12 @@ function RouteComponent() {
               <CardTitle className="text-lg">Transición de Estado</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
-              <div className="flex items-center justify-between rounded-lg border bg-slate-50 p-3 text-sm">
+              <div className="border-border bg-muted/20 flex items-center justify-between rounded-lg border p-3 text-sm">
                 <div className="text-center">
                   <p className="text-muted-foreground text-xs">Estado actual</p>
-                  <p className="font-bold">En Revisión</p>
+                  <p className="text-foreground font-bold">En Revisión</p>
                 </div>
-                <div className="mx-4 h-px flex-1 bg-slate-300" />
+                <div className="bg-border/30 mx-4 h-px flex-1" />
                 <div className="text-center">
                   <p className="text-muted-foreground text-xs">Siguiente</p>
                   <p className="text-primary font-bold">Revisión Expertos</p>


### PR DESCRIPTION
Fixes #103:
- Se aplicaron clases y tokens de tema a los modales de creación (Nuevo Plan, Nueva Asignatura, Nueva Bibliografía) para que respeten el modo oscuro.
- Se ajustaron tarjetas y paddings en las vistas de datos generales de asignatura para coherencia visual en dark.
- Se actualizó la tab de asignaturas, la tab de documento y la tab de contenido para usar las clases de tema y mejorar legibilidad en modo oscuro.
- Se adaptó la card de transición de estados (flujo/estados) y el diálogo de historial para respetar tokens de color y contrastes en dark.
- Se invirtió el tono del visor de documento para mejorar visibilidad en modo oscuro y se eliminó el uso de colores hardcodeados.