### PR TITLE
fix: admins pueden guardar borradores de campo en planes/asignaturas congelados

### DIFF
--- a/supabase/migrations/20260626120000_borradores_campo_admin_write.sql
+++ b/supabase/migrations/20260626120000_borradores_campo_admin_write.sql
@@ -1,0 +1,71 @@
+-- Fix: los administradores no podían guardar/borrar borradores de campo en
+-- planes/asignaturas "congelados" (fuera de su etapa normal de edición).
+--
+-- La UI habilita la edición para un ADMIN vía el "override administrativo"
+-- (planCapabilities.canEditWithOverride), por lo que el editor abre y
+-- autoguarda un borrador al cerrarse. Sin embargo, las políticas de escritura
+-- de borradores_campo usaban authz_plan_write_allowed(), que exige el header
+-- x-admin-override-reason. El cliente de borradores (drafts.api.ts) no envía
+-- ese header, así que el INSERT/UPDATE/DELETE fallaba con 42501.
+--
+-- Un borrador es espacio de trabajo temporal, no el dato oficial: la escritura
+-- auditada (con motivo de override) sigue siendo el paso "Aplicar" sobre la
+-- entidad real. Por eso aquí basta con permitir al ADMIN que puede ACCEDER a la
+-- entidad, sin exigir el header de motivo (que provocaría un prompt en cada
+-- autoguardado). El caso 'asignatura' además no tenía ninguna ruta de admin.
+
+DROP POLICY IF EXISTS borradores_campo_insert_by_scope ON public.borradores_campo;
+CREATE POLICY borradores_campo_insert_by_scope ON public.borradores_campo
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    CASE entidad
+      WHEN 'plan' THEN
+        public.usuario_puede_editar_plan(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_plan(entidad_id))
+      WHEN 'asignatura' THEN
+        public.usuario_puede_editar_asignatura(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_asignatura(entidad_id))
+      ELSE false
+    END
+  );
+
+DROP POLICY IF EXISTS borradores_campo_update_by_scope ON public.borradores_campo;
+CREATE POLICY borradores_campo_update_by_scope ON public.borradores_campo
+  FOR UPDATE TO authenticated
+  USING (
+    CASE entidad
+      WHEN 'plan' THEN
+        public.usuario_puede_editar_plan(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_plan(entidad_id))
+      WHEN 'asignatura' THEN
+        public.usuario_puede_editar_asignatura(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_asignatura(entidad_id))
+      ELSE false
+    END
+  )
+  WITH CHECK (
+    CASE entidad
+      WHEN 'plan' THEN
+        public.usuario_puede_editar_plan(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_plan(entidad_id))
+      WHEN 'asignatura' THEN
+        public.usuario_puede_editar_asignatura(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_asignatura(entidad_id))
+      ELSE false
+    END
+  );
+
+DROP POLICY IF EXISTS borradores_campo_delete_by_scope ON public.borradores_campo;
+CREATE POLICY borradores_campo_delete_by_scope ON public.borradores_campo
+  FOR DELETE TO authenticated
+  USING (
+    CASE entidad
+      WHEN 'plan' THEN
+        public.usuario_puede_editar_plan(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_plan(entidad_id))
+      WHEN 'asignatura' THEN
+        public.usuario_puede_editar_asignatura(auth.uid(), entidad_id)
+        OR (public.authz_is_admin() AND public.authz_can_access_asignatura(entidad_id))
+      ELSE false
+    END
+  );


### PR DESCRIPTION
## Problema

Al editar **Datos Generales** de un plan o asignatura **congelado** (fuera de su etapa normal de edición) como administrador, el guardado del borrador fallaba con:

```
{ "code": "42501", "message": "new row violates row-level security policy for table \"borradores_campo\"" }
```

## Causa

1. El frontend habilita la edición para el admin vía *override administrativo* (`canEditWithOverride` en `planCapabilities.ts`), así que el editor abre y **autoguarda un borrador al cerrarse** (`EditorCampoModal.closeWithDraftIfNeeded`).
2. Las políticas RLS de escritura de `borradores_campo` usaban `authz_plan_write_allowed()`, cuya rama de admin exige el header `x-admin-override-reason`.
3. Todas las demás APIs de escritura mandan ese header (`supabaseForOverride` / `supabaseBrowserWithHeaders`), pero `drafts.api.ts` usa un `supabaseBrowser()` pelado **sin header** → `authz_admin_override_reason()` es `NULL` → RLS rechaza.

Adicionalmente, el caso `'asignatura'` de las políticas no tenía **ninguna** ruta de admin.

## Cambio

Nueva migración `20260626120000_borradores_campo_admin_write.sql` que reescribe las políticas `INSERT`/`UPDATE`/`DELETE` de `borradores_campo` para que la ruta de admin sea:

```sql
public.authz_is_admin() AND public.authz_can_access_<plan|asignatura>(entidad_id)
```

es decir, sin exigir el header de motivo.

### Por qué relajar el RLS en lugar de mandar el header

Un *borrador* es espacio de trabajo temporal, **no** el dato oficial. La escritura auditada (con motivo de override) sigue siendo el paso **"Aplicar"** sobre la entidad real (`updatePlan` / `subjects_update`), que ya exige el motivo. Mandar el header en los borradores forzaría un prompt de motivo en **cada autoguardado al cerrar el editor** — mala UX.

## Notas para revisión

- Sentencias idempotentes (`DROP POLICY IF EXISTS` / `CREATE POLICY`).
- Validada con `ROLLBACK` y aplicada al contenedor local `supabase_db_Acad-IA`.
- **Falta aplicar al entorno hosted** con `supabase migration up`.
- Los usuarios no-admin no se ven afectados: en etapas editables (`BORRADOR`/`REVISION`) `usuario_puede_editar_plan` ya devolvía `true`, así que su comportamiento no cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)