### PR TITLE
test(db): alinear grants de publicación de recursos IA con el contrato del outbox

### DIFF
--- a/supabase/tests/database/learning_resources_atomic_publication.test.sql
+++ b/supabase/tests/database/learning_resources_atomic_publication.test.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(23);
+select plan(25);
 
 select ok(
   to_regprocedure(
@@ -25,12 +25,12 @@ select ok(
   'anon no puede publicar generaciones de recursos'
 );
 select ok(
-  has_function_privilege(
+  not has_function_privilege(
     'service_role',
     'public.publicar_generacion_recursos_ia(uuid,uuid,text,public.learning_generation_estado,text,timestamptz,jsonb,text,text,jsonb)',
     'execute'
   ),
-  'service_role puede publicar generaciones de recursos'
+  'service_role no puede llamar la primitiva interna de publicación'
 );
 select ok(
   not has_function_privilege(
@@ -40,8 +40,26 @@ select ok(
   ),
   'authenticated no puede inspeccionar la publicación interna'
 );
+select ok(
+  not has_function_privilege(
+    'service_role',
+    'public.consultar_publicacion_generacion_recursos_ia(uuid,text,text,text,jsonb)',
+    'execute'
+  ),
+  'service_role tampoco puede inspeccionar la primitiva de verificación'
+);
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.publicar_intento_recursos_ia(uuid,uuid,uuid,uuid,text,public.learning_generation_estado,text,timestamptz,jsonb)',
+    'execute'
+  ),
+  'service_role publica a través de la RPC del outbox'
+);
 
-set local role service_role;
+-- La primitiva ya no es invocable por service_role: los workers entran por
+-- publicar_intento_recursos_ia. Aquí se ejercita su lógica atómica como
+-- superusuario (dueño de la función), sin cambiar de rol.
 
 create temporary table learning_publication_fixture as
 select


### PR DESCRIPTION
## Qué cambia

Actualiza `supabase/tests/database/learning_resources_atomic_publication.test.sql` para reflejar el contrato de permisos vigente tras la migración `20260721203000_conectar_outbox_recursos_ia.sql`.

Esa migración dejó `public.publicar_generacion_recursos_ia(...)` como **primitiva interna** y revocó su `execute` a `public`, `anon`, `authenticated` **y `service_role`**. Los workers de API ahora publican a través de la RPC del outbox `public.publicar_intento_recursos_ia(...)`. El test, sin embargo, seguía afirmando que `service_role` podía invocar la primitiva, por lo que quedaba desalineado con el esquema real.

## Detalle

- **Assert invertido:** `service_role` **no** puede llamar la primitiva interna `publicar_generacion_recursos_ia(...)`.
- **Asserts nuevos (2):**
  - `service_role` tampoco puede inspeccionar `consultar_publicacion_generacion_recursos_ia(...)`.
  - `service_role` **sí** tiene `execute` sobre la RPC del outbox `publicar_intento_recursos_ia(uuid,uuid,uuid,uuid,text,learning_generation_estado,text,timestamptz,jsonb)`.
- **Eliminado `set local role service_role`:** con el grant revocado, ese rol ya no puede invocar la primitiva. El resto del test ejercita la lógica atómica como dueño de la función (superusuario), con un comentario que explica que los workers entran por el outbox.
- `plan(23)` → `plan(25)`.

## Por qué

El test es la especificación ejecutable del contrato de seguridad de la publicación de recursos IA. Tras convertir la función en primitiva interna, el test debía verificar la nueva frontera (outbox como único punto de entrada para `service_role`), no el grant anterior.

## Verificación

```
docker exec -i supabase_db_Acad-IA psql -U postgres -d postgres -q < supabase/tests/database/learning_resources_atomic_publication.test.sql
```

Salida: `1..25`, con los 25 asserts en `ok`.

## Notas para revisión

- Cambio limitado a un único archivo de test; no toca migraciones ni funciones.
- Los nombres de argumentos de la RPC del outbox en el nuevo assert coinciden exactamente con la firma declarada en la migración `20260721203000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)