### PR TITLE
Conecta previews con branches de Supabase

### DIFF
--- a/.github/actions/resolve-supabase-preview/action.yml
+++ b/.github/actions/resolve-supabase-preview/action.yml
@@ -1,0 +1,108 @@
+name: Resolve Supabase preview
+description: Waits for the native Supabase PR branch and exports its credentials.
+
+inputs:
+  branch-name:
+    description: Git branch associated with the Supabase preview branch.
+    required: true
+  head-sha:
+    description: Git head SHA whose Supabase Preview check must succeed.
+    required: true
+  project-ref:
+    description: Production project ref that owns the preview branches.
+    required: false
+  wait-seconds:
+    description: Maximum time to wait for the Supabase deployment.
+    required: false
+    default: '180'
+
+outputs:
+  available:
+    description: Whether a healthy Supabase preview branch was resolved.
+    value: ${{ steps.resolve.outputs.available }}
+  reason:
+    description: Reason why the preview branch was not resolved.
+    value: ${{ steps.resolve.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        BRANCH_NAME: ${{ inputs.branch-name }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        PROJECT_REF: ${{ inputs.project-ref }}
+        WAIT_SECONDS: ${{ inputs.wait-seconds }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+
+        echo "available=false" >> "$GITHUB_OUTPUT"
+
+        if [[ -z "$BRANCH_NAME" || -z "$HEAD_SHA" || -z "$PROJECT_REF" || -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
+          echo "reason=missing-configuration" >> "$GITHUB_OUTPUT"
+          echo "::notice::Supabase preview no esta configurado; se usara el fallback del workflow."
+          exit 0
+        fi
+
+        if [[ ! "$WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+          echo "reason=invalid-wait" >> "$GITHUB_OUTPUT"
+          echo "::error::wait-seconds debe ser un entero no negativo."
+          exit 1
+        fi
+
+        branch_environment="$(mktemp)"
+        trap 'rm -f "$branch_environment"' EXIT
+        deadline=$((SECONDS + WAIT_SECONDS))
+
+        while (( SECONDS <= deadline )); do
+          check_state="$(
+            gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs" \
+              --jq '[.check_runs[] | select(.app.slug == "supabase" and .name == "Supabase Preview")] | sort_by(.started_at) | last | if . == null then "pending" elif .status != "completed" then .status else "completed:" + (.conclusion // "unknown") end' \
+              2>/dev/null || true
+          )"
+
+          if [[ "$check_state" == "completed:success" ]]; then
+            if supabase branches get "$BRANCH_NAME" \
+              --project-ref "$PROJECT_REF" \
+              -o env > "$branch_environment" 2>/dev/null; then
+              set -a
+              # shellcheck disable=SC1090
+              source "$branch_environment"
+              set +a
+
+              if [[ -n "${SUPABASE_URL:-}" && -n "${SUPABASE_ANON_KEY:-}" && -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+                preview_project_ref="${SUPABASE_URL#https://}"
+                preview_project_ref="${preview_project_ref%%.*}"
+
+                echo "::add-mask::$SUPABASE_ANON_KEY"
+                echo "::add-mask::$SUPABASE_SERVICE_ROLE_KEY"
+                {
+                  printf 'VITE_SUPABASE_URL=%s\n' "$SUPABASE_URL"
+                  printf 'VITE_SUPABASE_ANON_KEY=%s\n' "$SUPABASE_ANON_KEY"
+                  printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n' "$SUPABASE_SERVICE_ROLE_KEY"
+                  printf 'SUPABASE_PREVIEW_PROJECT_REF=%s\n' "$preview_project_ref"
+                  echo 'ACADIA_SUPABASE_REMOTE_TESTS=1'
+                } >> "$GITHUB_ENV"
+                echo "available=true" >> "$GITHUB_OUTPUT"
+                echo "reason=resolved" >> "$GITHUB_OUTPUT"
+                echo "Supabase preview listo para $BRANCH_NAME."
+                exit 0
+              fi
+            fi
+          elif [[ "$check_state" == completed:* ]]; then
+            conclusion="${check_state#completed:}"
+            echo "reason=supabase-check-$conclusion" >> "$GITHUB_OUTPUT"
+            echo "::warning::Supabase Preview termino con '$conclusion'; no se usara una branch incompleta."
+            exit 0
+          fi
+
+          if (( SECONDS + 10 > deadline )); then
+            break
+          fi
+          sleep 10
+        done
+
+        echo "reason=timeout" >> "$GITHUB_OUTPUT"
+        echo "::notice::No aparecio una branch Supabase sana para $BRANCH_NAME en ${WAIT_SECONDS}s."

--- a/.github/actions/resolve-supabase-preview/action.yml
+++ b/.github/actions/resolve-supabase-preview/action.yml
@@ -12,9 +12,13 @@ inputs:
     description: Production project ref that owns the preview branches.
     required: false
   wait-seconds:
-    description: Maximum time to wait for the Supabase deployment.
+    description: Maximum time to wait for the Supabase check to start.
     required: false
-    default: '180'
+    default: '90'
+  deployment-wait-seconds:
+    description: Maximum additional time for a started deployment to finish.
+    required: false
+    default: '300'
 
 outputs:
   available:
@@ -34,6 +38,7 @@ runs:
         HEAD_SHA: ${{ inputs.head-sha }}
         PROJECT_REF: ${{ inputs.project-ref }}
         WAIT_SECONDS: ${{ inputs.wait-seconds }}
+        DEPLOYMENT_WAIT_SECONDS: ${{ inputs.deployment-wait-seconds }}
         GH_TOKEN: ${{ github.token }}
       run: |
         set -uo pipefail
@@ -46,15 +51,16 @@ runs:
           exit 0
         fi
 
-        if [[ ! "$WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+        if [[ ! "$WAIT_SECONDS" =~ ^[0-9]+$ || ! "$DEPLOYMENT_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
           echo "reason=invalid-wait" >> "$GITHUB_OUTPUT"
-          echo "::error::wait-seconds debe ser un entero no negativo."
+          echo "::error::Los tiempos de espera deben ser enteros no negativos."
           exit 1
         fi
 
         branch_environment="$(mktemp)"
         trap 'rm -f "$branch_environment"' EXIT
         deadline=$((SECONDS + WAIT_SECONDS))
+        deployment_started=0
 
         while (( SECONDS <= deadline )); do
           check_state="$(
@@ -62,6 +68,11 @@ runs:
               --jq '[.check_runs[] | select(.app.slug == "supabase" and .name == "Supabase Preview")] | sort_by(.started_at) | last | if . == null then "pending" elif .status != "completed" then .status else "completed:" + (.conclusion // "unknown") end' \
               2>/dev/null || true
           )"
+
+          if [[ -n "$check_state" && "$check_state" != "pending" && "$deployment_started" == '0' ]]; then
+            deployment_started=1
+            deadline=$((SECONDS + DEPLOYMENT_WAIT_SECONDS))
+          fi
 
           if [[ "$check_state" == "completed:success" ]]; then
             if supabase branches get "$BRANCH_NAME" \
@@ -104,5 +115,10 @@ runs:
           sleep 10
         done
 
-        echo "reason=timeout" >> "$GITHUB_OUTPUT"
-        echo "::notice::No aparecio una branch Supabase sana para $BRANCH_NAME en ${WAIT_SECONDS}s."
+        if [[ "$deployment_started" == '0' ]]; then
+          echo "reason=not-started" >> "$GITHUB_OUTPUT"
+          echo "::notice::Supabase no inicio el preview de $BRANCH_NAME en ${WAIT_SECONDS}s."
+        else
+          echo "reason=timeout" >> "$GITHUB_OUTPUT"
+          echo "::notice::La branch Supabase de $BRANCH_NAME no quedo sana en ${DEPLOYMENT_WAIT_SECONDS}s."
+        fi

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -45,7 +45,8 @@ jobs:
           branch-name: ${{ github.head_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}
           project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
-          wait-seconds: '180'
+          wait-seconds: '90'
+          deployment-wait-seconds: '300'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -1,0 +1,103 @@
+name: Azure Static Web Apps Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  deploy_preview:
+    name: Deploy preview with Supabase branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: preview
+    env:
+      AZURE_PREVIEW_URL: https://victorious-bay-0ca0aae10-${{ github.event.pull_request.number }}.3.azurestaticapps.net
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: supabase/setup-cli@v3
+        with:
+          version: 2.109.1
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve Supabase preview branch
+        id: supabase-preview
+        uses: ./.github/actions/resolve-supabase-preview
+        with:
+          branch-name: ${{ github.head_ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
+          wait-seconds: '180'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Configure preview function secrets
+        if: steps.supabase-preview.outputs.available == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CARBONE_API_TOKEN: ${{ secrets.CARBONE_API_TOKEN }}
+        shell: bash
+        run: |
+          secrets=("FRONTEND_URL=$AZURE_PREVIEW_URL")
+          if [[ -n "$OPENAI_API_KEY" ]]; then
+            secrets+=("OPENAI_API_KEY=$OPENAI_API_KEY")
+          fi
+          if [[ -n "$CARBONE_API_TOKEN" ]]; then
+            secrets+=("CARBONE_API_TOKEN=$CARBONE_API_TOKEN")
+          fi
+          supabase secrets set "${secrets[@]}" \
+            --project-ref "$SUPABASE_PREVIEW_PROJECT_REF"
+
+      - name: Build preview
+        if: steps.supabase-preview.outputs.available == 'true'
+        run: bunx --bun vite build
+
+      - name: Deploy Azure preview
+        if: steps.supabase-preview.outputs.available == 'true'
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_SWA_DEPLOYMENT_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: dist
+          output_location: ''
+          skip_app_build: true
+
+      - name: Close stale Azure preview
+        if: steps.supabase-preview.outputs.available != 'true'
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_SWA_DEPLOYMENT_TOKEN }}
+          app_location: '/'
+          action: close
+
+      - name: Report unavailable Supabase branch
+        if: steps.supabase-preview.outputs.available != 'true'
+        env:
+          REASON: ${{ steps.supabase-preview.outputs.reason }}
+        run: |
+          {
+            echo '### Azure preview omitido'
+            echo
+            echo "Supabase no entrego una branch sana para este commit (motivo: \`$REASON\`)."
+            echo 'No se desplego el frontend contra produccion.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -3,22 +3,6 @@ name: Visual Regression
 on:
   pull_request:
     branches: [main]
-    paths:
-      - .github/workflows/visual-tests.yml
-      - src/**
-      - public/**
-      - tests/visual/**
-      - scripts/run-visual-tests.ts
-      - scripts/update-linux-visual-snapshots.ts
-      - playwright.config.ts
-      - vite.config.*
-      - index.html
-      - package.json
-      - bun.lock
-      - supabase/config.toml
-      - supabase/migrations/**
-      - supabase/seed.sql
-      - supabase/seed.stage.sql
   workflow_dispatch:
 
 concurrency:
@@ -26,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  checks: read
   contents: read
 
 jobs:
@@ -33,8 +18,6 @@ jobs:
     name: Visual spacing regression
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      VITE_SUPABASE_URL: http://127.0.0.1:54321
 
     steps:
       - uses: actions/checkout@v7
@@ -42,6 +25,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+
+      - uses: supabase/setup-cli@v3
+        with:
+          version: 2.109.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -63,8 +50,20 @@ jobs:
         timeout-minutes: 3
         run: bunx playwright install --only-shell chromium
 
+      - name: Resolve Supabase preview branch
+        id: supabase-preview
+        uses: ./.github/actions/resolve-supabase-preview
+        with:
+          branch-name: ${{ github.head_ref || github.ref_name }}
+          head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
+          wait-seconds: '180'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - name: Start local Supabase stack
-        run: bunx supabase start
+        if: steps.supabase-preview.outputs.available != 'true'
+        run: supabase start
 
       - name: Compare visual surfaces
         run: bun run test:visual

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -57,7 +57,8 @@ jobs:
           branch-name: ${{ github.head_ref || github.ref_name }}
           head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
           project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
-          wait-seconds: '180'
+          wait-seconds: '90'
+          deployment-wait-seconds: '300'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 

--- a/scripts/run-visual-tests.ts
+++ b/scripts/run-visual-tests.ts
@@ -1,37 +1,67 @@
 export {}
 
-const supabaseStatus = Bun.spawnSync({
-  cmd: ['supabase', 'status', '-o', 'env'],
-  stdout: 'pipe',
-  stderr: 'pipe',
-})
-
-if (supabaseStatus.exitCode !== 0) {
-  console.error('Supabase local debe estar activo para las pruebas visuales.')
-  console.error(supabaseStatus.stderr.toString())
-  process.exit(supabaseStatus.exitCode)
+type SupabaseTestEnvironment = {
+  apiUrl: string
+  anonKey: string
+  serviceRoleKey: string
 }
 
-const localEnvironment = Object.fromEntries(
-  supabaseStatus.stdout
-    .toString()
-    .split(/\r?\n/)
-    .flatMap((line) => {
-      const match = line.match(/^([A-Z_]+)=(.*)$/)
-      if (!match) return []
-      const value = match[2].replace(/^['"]|['"]$/g, '')
-      return [[match[1], value]]
-    }),
-)
+function resolveRemoteEnvironment(): SupabaseTestEnvironment | undefined {
+  if (process.env.ACADIA_SUPABASE_REMOTE_TESTS !== '1') return undefined
 
-const apiUrl = localEnvironment.API_URL
-const anonKey = localEnvironment.ANON_KEY
-const serviceRoleKey = localEnvironment.SERVICE_ROLE_KEY
+  const apiUrl = process.env.VITE_SUPABASE_URL
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
-if (!apiUrl || !anonKey || !serviceRoleKey) {
-  console.error('No se pudieron leer las credenciales del Supabase local.')
-  process.exit(1)
+  if (!apiUrl || !anonKey || !serviceRoleKey) {
+    console.error(
+      'La branch Supabase remota no entrego todas las credenciales requeridas.',
+    )
+    process.exit(1)
+  }
+
+  return { apiUrl, anonKey, serviceRoleKey }
 }
+
+function resolveLocalEnvironment(): SupabaseTestEnvironment {
+  const supabaseStatus = Bun.spawnSync({
+    cmd: ['supabase', 'status', '-o', 'env'],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (supabaseStatus.exitCode !== 0) {
+    console.error('Supabase local debe estar activo para las pruebas visuales.')
+    console.error(supabaseStatus.stderr.toString())
+    process.exit(supabaseStatus.exitCode)
+  }
+
+  const localEnvironment = Object.fromEntries(
+    supabaseStatus.stdout
+      .toString()
+      .split(/\r?\n/)
+      .flatMap((line) => {
+        const match = line.match(/^([A-Z_]+)=(.*)$/)
+        if (!match) return []
+        const value = match[2].replace(/^['"]|['"]$/g, '')
+        return [[match[1], value]]
+      }),
+  )
+
+  const apiUrl = localEnvironment.API_URL
+  const anonKey = localEnvironment.ANON_KEY
+  const serviceRoleKey = localEnvironment.SERVICE_ROLE_KEY
+
+  if (!apiUrl || !anonKey || !serviceRoleKey) {
+    console.error('No se pudieron leer las credenciales del Supabase local.')
+    process.exit(1)
+  }
+
+  return { apiUrl, anonKey, serviceRoleKey }
+}
+
+const { apiUrl, anonKey, serviceRoleKey } =
+  resolveRemoteEnvironment() ?? resolveLocalEnvironment()
 
 const playwright = Bun.spawnSync({
   cmd: ['bunx', 'playwright', 'test', ...Bun.argv.slice(2)],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,21 +7,20 @@ sql_paths = ["./seed.stage.sql", "./seed.sql"]
 
 [auth]
 site_url = "http://localhost:3000"
-additional_redirect_urls = ["http://127.0.0.1:3000/**", "http://localhost:3000/**"]
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/**",
+  "http://localhost:3000/**",
+  "https://victorious-bay-0ca0aae10-*.3.azurestaticapps.net/**",
+]
 
 [auth.email]
 enable_signup = true
 enable_confirmations = true
 double_confirm_changes = true
 
-[auth.email.smtp]
-enabled = true
-host = "env(SMTP_HOST)"
-port = 587
-user = "env(SMTP_USER)"
-pass = "env(SMTP_PASS)"
-admin_email = "env(SMTP_ADMIN_EMAIL)"
-sender_name = "env(SMTP_SENDER_NAME)"
+# El SMTP personalizado de produccion se administra en el Dashboard. Las
+# branches preview usan el servicio de correo predeterminado de Supabase y no
+# dependen de secretos de produccion durante su creacion.
 
 [functions.ai-generate-plan]
 enabled = true


### PR DESCRIPTION
## Resumen
- espera la branch nativa de Supabase y exporta sus credenciales sin imprimir secretos
- usa Supabase local sólo como fallback de las pruebas visuales
- despliega Azure Preview contra la branch del PR y configura sus secretos/redirects
- elimina el SMTP de producción del config compartido que rompía la creación de branches

## Validación
- 147 unit tests
- typecheck, ESLint (sin errores), Prettier de archivos modificados y actionlint
- Playwright autenticado usando el camino de credenciales remotas
- corrida visual completa: 44 pasan; 11 difieren por snapshots locales existentes