### PR TITLE
Add safe webhook runtime diagnostics

### DIFF
--- a/api/src/functions/openai-webhook.js
+++ b/api/src/functions/openai-webhook.js
@@ -2,6 +2,7 @@ import { app } from '@azure/functions'
 import OpenAI from 'openai'
 
 import { createWebhookRelaySigner } from '../lib/relay-signature.js'
+import { routerConfigurationCode } from '../lib/router-diagnostic.js'
 import {
   createSupabaseBranchValidator,
   createWebhookRouter,
@@ -60,7 +61,10 @@ async function openAIWebhook(request, context) {
   } catch (error) {
     routerPromise = null
     context.error('OpenAI webhook router is not configured.', error)
-    return { status: 503, body: 'Webhook router unavailable' }
+    return {
+      status: 503,
+      body: `Webhook router unavailable (${routerConfigurationCode(error)})`,
+    }
   }
 }
 

--- a/api/src/lib/router-diagnostic.js
+++ b/api/src/lib/router-diagnostic.js
@@ -1,0 +1,27 @@
+const MISSING_SETTING_PATTERN =
+  /^Missing Azure Static Web App setting: ([A-Z0-9_]+)$/
+
+const SAFE_ERROR_NAMES = new Set([
+  'DataError',
+  'NotSupportedError',
+  'OperationError',
+  'SyntaxError',
+  'TypeError',
+])
+
+export function routerConfigurationCode(error) {
+  const message = error instanceof Error ? error.message : ''
+  const missingSetting = message.match(MISSING_SETTING_PATTERN)?.[1]
+
+  if (missingSetting) return `missing_${missingSetting.toLowerCase()}`
+  if (message === 'SUPABASE_PARENT_PROJECT_REF is invalid.') {
+    return 'invalid_supabase_parent_project_ref'
+  }
+
+  const errorName = error instanceof Error ? error.name : ''
+  if (SAFE_ERROR_NAMES.has(errorName)) {
+    return `initialization_${errorName.toLowerCase()}`
+  }
+
+  return 'initialization_error'
+}

--- a/api/test/router-diagnostic.test.js
+++ b/api/test/router-diagnostic.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { routerConfigurationCode } from '../src/lib/router-diagnostic.js'
+
+describe('Azure webhook router diagnostics', () => {
+  it('identifica una variable faltante sin incluir su valor', () => {
+    const result = routerConfigurationCode(
+      new Error('Missing Azure Static Web App setting: OPENAI_API_KEY'),
+    )
+
+    assert.equal(result, 'missing_openai_api_key')
+  })
+
+  it('reduce errores inesperados a una categoría segura', () => {
+    const error = new Error('secret-bearing internal detail')
+    error.name = 'UnexpectedSecretError'
+
+    assert.equal(routerConfigurationCode(error), 'initialization_error')
+  })
+
+  it('conserva sólo nombres de error permitidos', () => {
+    const error = new TypeError('implementation detail')
+
+    assert.equal(routerConfigurationCode(error), 'initialization_typeerror')
+  })
+})


### PR DESCRIPTION
Adds a sanitized initialization code to 503 responses from the Azure webhook router. The response can identify a missing setting or safe error category without exposing configuration values. Includes API unit tests.