### PR TITLE
Read Azure webhook body from request buffer

### DIFF
--- a/api/src/functions/openai-webhook.js
+++ b/api/src/functions/openai-webhook.js
@@ -2,6 +2,7 @@ import { app } from '@azure/functions'
 import OpenAI from 'openai'
 
 import { createWebhookRelaySigner } from '../lib/relay-signature.js'
+import { readWebhookBody } from '../lib/request-body.js'
 import {
   initializeRouterStage,
   routerConfigurationCode,
@@ -57,17 +58,10 @@ async function buildRouter() {
 }
 
 async function openAIWebhook(request, context) {
+  let router
   try {
     routerPromise ??= buildRouter()
-    const router = await routerPromise
-    return await router(
-      {
-        method: request.method,
-        rawBody: await request.text(),
-        headers: request.headers,
-      },
-      context,
-    )
+    router = await routerPromise
   } catch (error) {
     routerPromise = null
     context.error('OpenAI webhook router is not configured.', error)
@@ -75,6 +69,28 @@ async function openAIWebhook(request, context) {
       status: 503,
       body: `Webhook router unavailable (${routerConfigurationCode(error)})`,
     }
+  }
+
+  let rawBody
+  try {
+    rawBody = await readWebhookBody(request)
+  } catch (error) {
+    context.error('OpenAI webhook request body could not be read.', error)
+    return { status: 400, body: 'Invalid webhook request' }
+  }
+
+  try {
+    return await router(
+      {
+        method: request.method,
+        rawBody,
+        headers: request.headers,
+      },
+      context,
+    )
+  } catch (error) {
+    context.error('OpenAI webhook router failed unexpectedly.', error)
+    return { status: 500, body: 'Webhook routing failed' }
   }
 }
 

--- a/api/src/lib/request-body.js
+++ b/api/src/lib/request-body.js
@@ -1,0 +1,9 @@
+const decoder = new TextDecoder()
+
+export async function readWebhookBody(request) {
+  if (typeof request?.arrayBuffer !== 'function') {
+    throw new TypeError('Azure webhook request has no arrayBuffer method.')
+  }
+
+  return decoder.decode(await request.arrayBuffer())
+}

--- a/api/test/request-body.test.js
+++ b/api/test/request-body.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { readWebhookBody } from '../src/lib/request-body.js'
+
+describe('Azure webhook request body', () => {
+  it('decodifica exactamente el JSON UTF-8 usado para verificar la firma', async () => {
+    const rawBody = '{"message":"Webhook de Acadia 🎓"}'
+    const request = {
+      arrayBuffer: async () => new TextEncoder().encode(rawBody).buffer,
+    }
+
+    assert.equal(await readWebhookBody(request), rawBody)
+  })
+
+  it('rechaza objetos que no sean HttpRequest de Azure', async () => {
+    await assert.rejects(() => readWebhookBody({}), TypeError)
+  })
+})


### PR DESCRIPTION
Separates router initialization from HTTP body handling and reads the original UTF-8 payload through Azure HttpRequest.arrayBuffer(). This prevents request-body failures from being reported as configuration errors and preserves the exact body used for OpenAI signature verification. Includes unit coverage.