### PR TITLE
Bind Azure invocation logger methods

### DIFF
--- a/api/src/lib/webhook-router.js
+++ b/api/src/lib/webhook-router.js
@@ -32,10 +32,16 @@ function getHeader(headers, name) {
 }
 
 function safeLogger(logger) {
+  const bind = (name) => {
+    if (typeof logger?.[name] === 'function') return logger[name].bind(logger)
+    if (typeof logger?.log === 'function') return logger.log.bind(logger)
+    return () => undefined
+  }
+
   return {
-    info: logger?.info ?? logger?.log ?? (() => undefined),
-    warn: logger?.warn ?? logger?.log ?? (() => undefined),
-    error: logger?.error ?? logger?.log ?? (() => undefined),
+    info: bind('info'),
+    warn: bind('warn'),
+    error: bind('error'),
   }
 }
 

--- a/api/test/webhook-router.test.js
+++ b/api/test/webhook-router.test.js
@@ -64,6 +64,28 @@ describe('Azure OpenAI webhook router', () => {
     assert.equal(retrieved, false)
   })
 
+  it('conserva el contexto de los métodos de logging de Azure', async () => {
+    const router = createWebhookRouter(
+      dependencies({
+        verifyWebhook: async () => {
+          throw new Error('invalid signature')
+        },
+      }),
+    )
+    let warned = false
+    const context = {
+      warn() {
+        assert.equal(this, context)
+        warned = true
+      },
+    }
+
+    const result = await router(request(), context)
+
+    assert.equal(result.status, 400)
+    assert.equal(warned, true)
+  })
+
   it('enruta a la branch indicada y firma el cuerpo original', async () => {
     let downstreamUrl = ''
     let downstreamInit


### PR DESCRIPTION
Keeps Azure InvocationContext as this when forwarding info, warn and error methods. Without binding, a rejected webhook signature throws inside the logger and returns 500. Includes a regression test.