### PR TITLE
refactor(aks): mount Edge Functions from existing PVC

### DIFF
--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -98,6 +98,11 @@ jobs:
         with:
           version: v3.18.6
 
+      - name: Package Functions source
+        id: functions_source
+        shell: bash
+        run: bash deploy/scripts/package-functions-source.sh "$GITHUB_SHA" /tmp/functions.tar.gz
+
       - name: Validate Helm chart
         run: |
           helm repo add supabase-community https://supabase-community.github.io/supabase-kubernetes
@@ -106,10 +111,10 @@ jobs:
           helm template "$RELEASE_NAME" "$CHART_PATH" \
             --namespace acad-ia-backend \
             -f "$CHART_PATH/values-production.example.yaml" \
-            --set-string images.functions.tag="${GITHUB_SHA}" \
-            --set-string 'supabase.deployment.studio.volumes[0].name'="functions-source" \
-            --set-string 'supabase.deployment.studio.volumes[0].image.reference'="myregistry.azurecr.io/acad-ia-functions:${GITHUB_SHA}" \
-            --set-string 'supabase.deployment.studio.volumes[0].image.pullPolicy'="IfNotPresent" \
+            --set-string functions.source.revision="${GITHUB_SHA}" \
+            --set-string functions.source.bundleConfigMapName="acad-ia-functions-source-${GITHUB_SHA:0:32}" \
+            --set-string functions.source.bundleSha256="${{ steps.functions_source.outputs.sha256 }}" \
+            --set-string 'supabase.environment.studio[7].value'="${GITHUB_SHA}" \
             --set-string images.migrator.tag="${GITHUB_SHA}" \
             --set-string images.backup.tag="${GITHUB_SHA}" \
             > /tmp/acad-ia-backend.yaml
@@ -151,7 +156,6 @@ jobs:
           push: true
           files: deploy/docker-bake.hcl
           set: |
-            functions.tags=${{ vars.ACR_LOGIN_SERVER }}/acad-ia-functions:${{ github.sha }}
             migrator.tags=${{ vars.ACR_LOGIN_SERVER }}/acad-ia-migrator:${{ github.sha }}
             backup.tags=${{ vars.ACR_LOGIN_SERVER }}/acad-ia-backup:${{ github.sha }}
 
@@ -339,6 +343,14 @@ jobs:
               ;;
           esac
 
+      - name: Publish immutable Functions source
+        id: functions_source
+        env:
+          AKS_NAMESPACE: ${{ vars.AKS_NAMESPACE }}
+          FUNCTIONS_SOURCE_REVISION: ${{ github.sha }}
+        shell: bash
+        run: bash deploy/scripts/publish-functions-source.sh
+
       - name: Deploy backend-only release
         env:
           BACKEND_HOST: ${{ vars.AKS_BACKEND_HOST }}
@@ -361,11 +373,10 @@ jobs:
             --set-string frontendUrl="${FRONTEND_URL}" \
             --set-string ingress.host="${BACKEND_HOST}" \
             --set-string backups.endpoint="${RUSTFS_ENDPOINT}" \
-            --set-string images.functions.repository="${ACR_LOGIN_SERVER}/acad-ia-functions" \
-            --set-string images.functions.tag="${GITHUB_SHA}" \
-            --set-string 'supabase.deployment.studio.volumes[0].name'="functions-source" \
-            --set-string 'supabase.deployment.studio.volumes[0].image.reference'="${ACR_LOGIN_SERVER}/acad-ia-functions:${GITHUB_SHA}" \
-            --set-string 'supabase.deployment.studio.volumes[0].image.pullPolicy'="IfNotPresent" \
+            --set-string functions.source.revision="${GITHUB_SHA}" \
+            --set-string functions.source.previousRevision="${{ steps.functions_source.outputs.previous_revision }}" \
+            --set-string functions.source.bundleConfigMapName="${{ steps.functions_source.outputs.config_map_name }}" \
+            --set-string functions.source.bundleSha256="${{ steps.functions_source.outputs.bundle_sha256 }}" \
             --set-string images.migrator.repository="${ACR_LOGIN_SERVER}/acad-ia-migrator" \
             --set-string images.migrator.tag="${GITHUB_SHA}" \
             --set-string images.backup.repository="${ACR_LOGIN_SERVER}/acad-ia-backup" \
@@ -374,7 +385,8 @@ jobs:
             --set-string 'supabase.environment.auth[1].value'="https://${BACKEND_HOST}/auth/v1" \
             --set-string 'supabase.environment.auth[4].value'="${FRONTEND_URL}" \
             --set-string 'supabase.environment.auth[5].value'="${FRONTEND_URL}/**" \
-            --set-string 'supabase.environment.studio[4].value'="https://${BACKEND_HOST}"
+            --set-string 'supabase.environment.studio[4].value'="https://${BACKEND_HOST}" \
+            --set-string 'supabase.environment.studio[7].value'="${GITHUB_SHA}"
 
       - name: Synchronize AI recovery schedules
         env:
@@ -407,6 +419,46 @@ jobs:
             --header 'content-type: application/json' \
             --data '{}')"
           test "$status" = '400'
+
+      - name: Prune obsolete Functions source revisions
+        env:
+          AKS_NAMESPACE: ${{ vars.AKS_NAMESPACE }}
+          FUNCTIONS_SOURCE_REVISION: ${{ github.sha }}
+          FUNCTIONS_SOURCE_RETAINED: '5'
+        shell: bash
+        run: bash deploy/scripts/prune-functions-source-configmaps.sh
+
+      - name: Remove obsolete Functions image repository
+        env:
+          ACR_NAME: ${{ vars.ACR_NAME }}
+          AKS_NAMESPACE: ${{ vars.AKS_NAMESPACE }}
+        shell: bash
+        run: |
+          live_references="$(kubectl get deployment \
+            --namespace "$AKS_NAMESPACE" \
+            -o json | jq -r '
+              .items[]
+              | (.spec.template.spec.containers[]?.image,
+                 .spec.template.spec.initContainers[]?.image,
+                 .spec.template.spec.volumes[]?.image?.reference)
+              | select(. != null)')"
+          if grep -Fq '/acad-ia-functions:' <<<"$live_references"; then
+            echo '::error::A live Deployment still references acad-ia-functions; refusing to remove the repository.'
+            exit 1
+          fi
+
+          if az acr repository show \
+            --name "$ACR_NAME" \
+            --repository acad-ia-functions \
+            --output none \
+            --only-show-errors 2>/dev/null; then
+            az acr repository delete \
+              --name "$ACR_NAME" \
+              --repository acad-ia-functions \
+              --yes \
+              --output none \
+              --only-show-errors
+          fi
 
       - name: Collect deployment diagnostics
         if: ${{ failure() || cancelled() }}

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -20,14 +20,15 @@ Runtime de este chart.
   32 GiB. No se usa MinIO ni un S3 externo como almacenamiento primario.
 - `storage-api` e `imgproxy` comparten el PVC y ejecutan una réplica con
   estrategia `Recreate`, coherente con `ReadWriteOnce`.
-- Edge Functions empaquetadas en una imagen propia, con JWT obligatorio salvo
-  la lista pública auditada por el router.
+- Edge Runtime oficial `v1.74.3`, fijado también por digest, con JWT obligatorio
+  salvo la lista pública auditada por el router.
 - Supavisor, migraciones, probes, recursos, PDB e Ingress TLS.
 - TLS público automatizado con cert-manager 1.21.1 y Let's Encrypt.
 - CronJob semanal de respaldo hacia RustFS con retención de 84 días.
-- Studio enumera Edge Functions desde la misma imagen OCI inmutable que ejecuta
-  el runtime; el volumen de imagen es de sólo lectura y GitHub sigue siendo la
-  fuente de despliegue.
+- GitHub empaqueta sólo el código de Functions en un ConfigMap inmutable. Un Job
+  de Helm lo valida y lo instala como revisión de sólo lectura en el PVC de
+  snippets que Studio ya utiliza; Edge Runtime y Studio montan la misma
+  revisión. Se conservan cinco revisiones para rollback.
 
 El chart padre envuelve `supabase-community/supabase-kubernetes` 0.7.2 y
 reemplaza las piezas que requieren el comportamiento actual de Acad-IA. No usa
@@ -206,13 +207,22 @@ operaciones de Azure CLI usan `--file`; ningún workflow imprime los valores.
 
 ## Imágenes y migraciones
 
-GitHub Actions construye tres imágenes:
+GitHub Actions construye dos imágenes:
 
-- `acad-ia-functions`: Edge Functions y router por función.
 - `acad-ia-migrator`: Supabase CLI 2.115.0, cliente Postgres 17, migraciones y
   seed idempotente.
 - `acad-ia-backup`: cliente Postgres 17, `rclone` y el procedimiento de
   respaldo.
+
+Functions usa directamente
+`supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.
+No se copia código a un pod o nodo con `scp`: esos sistemas de archivos son
+efímeros en AKS. El equivalente reproducible del volumen recomendado por
+Supabase es una revisión inmutable en el PVC existente. Tras comprobar el
+webhook y verificar que no quedan referencias vivas, el workflow elimina por
+completo el repositorio ACR legado `acad-ia-functions`. La revisión Helm previa
+basada en esa imagen deja de ser un rollback válido; para volver atrás se
+redepliega el commit deseado mediante este mismo workflow.
 
 El Job de Helm ejecuta `supabase migration up --include-all` y después el seed.
 Antes de migrar espera hasta diez minutos a que Postgres esté disponible; esto
@@ -405,6 +415,7 @@ y una ventana de corte.
 ```bash
 node --test deploy/scripts/generate-supabase-secrets.test.mjs
 bash -n deploy/scripts/publish-key-vault-to-vaultwarden.sh
+bash deploy/scripts/package-functions-source.sh HEAD /tmp/functions.tar.gz
 docker compose --env-file .env.example config --quiet
 docker buildx bake --file deploy/docker-bake.hcl
 helm repo add supabase-community \

--- a/deploy/docker-bake.hcl
+++ b/deploy/docker-bake.hcl
@@ -3,13 +3,7 @@ variable "TAG" {
 }
 
 group "default" {
-  targets = ["functions", "migrator", "backup"]
-}
-
-target "functions" {
-  context = "supabase/functions"
-  dockerfile = "Dockerfile"
-  tags = ["acad-ia-functions:${TAG}"]
+  targets = ["migrator", "backup"]
 }
 
 target "migrator" {

--- a/deploy/helm/acad-ia-backend/Chart.yaml
+++ b/deploy/helm/acad-ia-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: acad-ia-backend
 description: Backend-only Supabase stack for Acad-IA on AKS
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 'self-hosted/v0.8.0'
 dependencies:
   - name: supabase

--- a/deploy/helm/acad-ia-backend/templates/functions-source-job.yaml
+++ b/deploy/helm/acad-ia-backend/templates/functions-source-job.yaml
@@ -1,0 +1,134 @@
+{{- if .Values.functions.source.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-functions-source
+  labels:
+    {{- include "acad-ia-backend.labels" . | nindent 4 }}
+    app.kubernetes.io/component: functions-source
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,pre-rollback
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "acad-ia-backend.labels" . | nindent 8 }}
+        app.kubernetes.io/component: functions-source
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: install
+          image: {{ .Values.functions.source.installerImage | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              revision={{ .Values.functions.source.revision | quote }}
+              previous_revision={{ .Values.functions.source.previousRevision | quote }}
+              expected_sha={{ .Values.functions.source.bundleSha256 | quote }}
+              retained={{ .Values.functions.source.retainedReleases }}
+              releases=/source/functions/releases
+
+              valid_revision() {
+                value="$1"
+                [ "${#value}" -eq 40 ] || return 1
+                case "$value" in
+                  *[!0-9a-f]*) return 1 ;;
+                esac
+              }
+
+              valid_revision "$revision"
+              [ "${#expected_sha}" -eq 64 ]
+              case "$expected_sha" in
+                *[!0-9a-f]*) exit 1 ;;
+              esac
+              [ "$retained" -ge 2 ]
+
+              mkdir -p "$releases"
+              release="$releases/$revision"
+              staging="$releases/.${revision}.staging"
+
+              echo "$expected_sha  /bundle/functions.tar.gz" | sha256sum -c -
+              if [ -d "$release" ]; then
+                test "$(cat "$release/.bundle-sha256")" = "$expected_sha"
+                test -f "$release/main/index.ts"
+              else
+                rm -rf -- "$staging"
+                mkdir -p "$staging"
+                tar -xzf /bundle/functions.tar.gz -C "$staging" --strip-components=2
+                test -f "$staging/main/index.ts"
+                printf '%s\n' "$expected_sha" > "$staging/.bundle-sha256"
+                chmod -R a=rX "$staging"
+                mv "$staging" "$release"
+              fi
+
+              keep=/tmp/functions-releases.keep
+              ordered=/tmp/functions-releases.ordered
+              : > "$keep"
+              printf '%s\n' "$revision" >> "$keep"
+              if valid_revision "$previous_revision" && [ -d "$releases/$previous_revision" ]; then
+                printf '%s\n' "$previous_revision" >> "$keep"
+              fi
+              sort -u "$keep" -o "$keep"
+
+              : > "$ordered"
+              for directory in "$releases"/*; do
+                [ -d "$directory" ] || continue
+                name="${directory##*/}"
+                valid_revision "$name" || continue
+                stat -c '%Y %n' "$directory"
+              done | sort -rn | sed 's|.*/||' > "$ordered"
+
+              while IFS= read -r name; do
+                [ -n "$name" ] || continue
+                if grep -Fqx "$name" "$keep"; then
+                  continue
+                fi
+                if [ "$(wc -l < "$keep")" -lt "$retained" ]; then
+                  printf '%s\n' "$name" >> "$keep"
+                fi
+              done < "$ordered"
+
+              while IFS= read -r name; do
+                valid_revision "$name" || continue
+                if ! grep -Fqx "$name" "$keep"; then
+                  candidate="$releases/$name"
+                  test "${candidate#"$releases/"}" = "$name"
+                  rm -rf -- "$candidate"
+                fi
+              done < "$ordered"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: bundle
+              mountPath: /bundle
+              readOnly: true
+            - name: source
+              mountPath: /source
+      volumes:
+        - name: bundle
+          configMap:
+            name: {{ required "functions.source.bundleConfigMapName is required" .Values.functions.source.bundleConfigMapName }}
+        - name: source
+          persistentVolumeClaim:
+            claimName: {{ required "functions.source.pvcName is required" .Values.functions.source.pvcName }}
+{{- end }}

--- a/deploy/helm/acad-ia-backend/templates/functions.yaml
+++ b/deploy/helm/acad-ia-backend/templates/functions.yaml
@@ -22,11 +22,13 @@ spec:
         app.kubernetes.io/name: supabase-functions
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: functions
+      annotations:
+        acad-ia.ulsa.mx/functions-source-revision: {{ required "functions.source.revision is required" .Values.functions.source.revision | quote }}
     spec:
       automountServiceAccountToken: false
       containers:
         - name: functions
-          image: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
+          image: "{{ .Values.supabase.image.functions.repository }}:{{ .Values.supabase.image.functions.tag }}@{{ .Values.supabase.image.functions.digest }}"
           imagePullPolicy: IfNotPresent
           args: ["start", "--main-service", "/home/deno/functions/main"]
           ports:
@@ -80,6 +82,8 @@ spec:
               value: "true"
             - name: FUNCTIONS_PUBLIC_NAMES
               value: {{ .Values.functions.publicNames | quote }}
+            - name: FUNCTIONS_SOURCE_REVISION
+              value: {{ required "functions.source.revision is required" .Values.functions.source.revision | quote }}
             - name: DB_PASSWORD_ENC
               valueFrom:
                 secretKeyRef:
@@ -107,10 +111,19 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.functions.resources | nindent 12 }}
+          volumeMounts:
+            - name: functions-source
+              mountPath: /home/deno/functions
+              subPathExpr: functions/releases/$(FUNCTIONS_SOURCE_REVISION)
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+      volumes:
+        - name: functions-source
+          persistentVolumeClaim:
+            claimName: {{ required "functions.source.pvcName is required" .Values.functions.source.pvcName }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/acad-ia-backend/values-production.example.yaml
+++ b/deploy/helm/acad-ia-backend/values-production.example.yaml
@@ -2,8 +2,6 @@ publicUrl: https://supabase.acad-ia.example.edu.mx
 frontendUrl: https://acad-ia.example.edu.mx
 
 images:
-  functions:
-    repository: myregistry.azurecr.io/acad-ia-functions
   migrator:
     repository: myregistry.azurecr.io/acad-ia-migrator
   backup:
@@ -101,3 +99,5 @@ supabase:
         value: http://supabase-envoy:8000
       - name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
         value: /home/deno/functions
+      - name: FUNCTIONS_SOURCE_REVISION
+        value: '0000000000000000000000000000000000000000'

--- a/deploy/helm/acad-ia-backend/values.yaml
+++ b/deploy/helm/acad-ia-backend/values.yaml
@@ -8,9 +8,6 @@ images:
   envoy:
     repository: envoyproxy/envoy
     tag: v1.39.0
-  functions:
-    repository: example.azurecr.io/acad-ia-functions
-    tag: latest
   migrator:
     repository: example.azurecr.io/acad-ia-migrator
     tag: latest
@@ -42,6 +39,15 @@ envoy:
 functions:
   replicas: 1
   publicNames: openai-webhook-responses,process-file-jobs,openai-responses,usuarios-alta-directa,external-auth,internal-auth-login,learning-package-cleanup,observability-health
+  source:
+    enabled: true
+    revision: '0000000000000000000000000000000000000000'
+    previousRevision: ''
+    bundleConfigMapName: acad-ia-functions-source-00000000000000000000000000000000
+    bundleSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    pvcName: acad-ia-backend-supabase-snippets
+    retainedReleases: 5
+    installerImage: alpine:3.22.1
   resources:
     requests:
       cpu: 100m
@@ -238,17 +244,12 @@ supabase:
       strategy:
         type: Recreate
       volumeMounts:
-        - name: functions-source
+        # Reuse Studio's existing snippets PVC. The source publisher stores
+        # immutable releases below functions/releases/<git-sha>.
+        - name: snippets-storage
           mountPath: /home/deno/functions
-          subPath: home/deno/functions
+          subPathExpr: functions/releases/$(FUNCTIONS_SOURCE_REVISION)
           readOnly: true
-      volumes:
-        - name: functions-source
-          image:
-            # The deployment workflow pins this reference to the same immutable
-            # image digest/tag used by the Edge Runtime workload.
-            reference: example.azurecr.io/acad-ia-functions:latest
-            pullPolicy: IfNotPresent
     functions:
       enabled: false
       fullnameOverride: supabase-functions
@@ -263,7 +264,8 @@ supabase:
       tag: 17.6.1.136
     functions:
       repository: supabase/edge-runtime
-      tag: v1.74.0
+      tag: v1.74.3
+      digest: sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c
     imgproxy:
       repository: darthsim/imgproxy
       tag: v3.30.1
@@ -364,6 +366,8 @@ supabase:
         value: http://supabase-envoy:8000
       - name: EDGE_FUNCTIONS_MANAGEMENT_FOLDER
         value: /home/deno/functions
+      - name: FUNCTIONS_SOURCE_REVISION
+        value: '0000000000000000000000000000000000000000'
   persistence:
     db:
       enabled: true

--- a/deploy/scripts/package-functions-source.sh
+++ b/deploy/scripts/package-functions-source.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly REVISION="${1:-HEAD}"
+readonly OUTPUT="${2:?Usage: package-functions-source.sh [revision] output.tar.gz}"
+readonly MAX_BYTES="${FUNCTIONS_BUNDLE_MAX_BYTES:-900000}"
+REPOSITORY_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPOSITORY_ROOT
+
+temporary_tar="$(mktemp)"
+temporary_listing="$(mktemp)"
+trap 'rm -f "$temporary_tar" "$temporary_listing"' EXIT
+
+git -C "$REPOSITORY_ROOT" archive \
+  --format=tar \
+  --output="$temporary_tar" \
+  "$REVISION" \
+  -- supabase/functions \
+  ':(exclude)supabase/functions/Dockerfile' \
+  ':(exclude)supabase/functions/.dockerignore' \
+  ':(exclude)supabase/functions/tests'
+gzip -n -9 < "$temporary_tar" > "$OUTPUT"
+
+size="$(stat -c '%s' "$OUTPUT")"
+if (( size > MAX_BYTES )); then
+  printf 'Functions bundle is %s bytes; the limit is %s bytes.\n' "$size" "$MAX_BYTES" >&2
+  exit 1
+fi
+
+tar -tzf "$OUTPUT" > "$temporary_listing"
+grep -Fqx 'supabase/functions/main/index.ts' "$temporary_listing"
+sha256="$(sha256sum "$OUTPUT" | cut -d ' ' -f 1)"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'archive=%s\n' "$OUTPUT"
+    printf 'bytes=%s\n' "$size"
+    printf 'sha256=%s\n' "$sha256"
+  } >> "$GITHUB_OUTPUT"
+else
+  printf 'archive=%s\nbytes=%s\nsha256=%s\n' "$OUTPUT" "$size" "$sha256"
+fi

--- a/deploy/scripts/prune-functions-source-configmaps.sh
+++ b/deploy/scripts/prune-functions-source-configmaps.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AKS_NAMESPACE:?AKS_NAMESPACE is required}"
+: "${FUNCTIONS_SOURCE_REVISION:?FUNCTIONS_SOURCE_REVISION is required}"
+
+readonly RETAINED="${FUNCTIONS_SOURCE_RETAINED:-5}"
+
+if [[ ! "$FUNCTIONS_SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'FUNCTIONS_SOURCE_REVISION must be a full lowercase Git SHA.\n' >&2
+  exit 1
+fi
+if [[ ! "$RETAINED" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'FUNCTIONS_SOURCE_RETAINED must be a positive integer.\n' >&2
+  exit 1
+fi
+
+current="acad-ia-functions-source-${FUNCTIONS_SOURCE_REVISION:0:32}"
+mapfile -t ordered < <(
+  kubectl get configmap \
+    --namespace "$AKS_NAMESPACE" \
+    --selector 'app.kubernetes.io/component=functions-source' \
+    -o json |
+    jq -r '.items
+      | sort_by(.metadata.creationTimestamp)
+      | reverse
+      | .[].metadata.name'
+)
+
+keep=("$current")
+for name in "${ordered[@]}"; do
+  [[ "$name" =~ ^acad-ia-functions-source-[0-9a-f]{32}$ ]] || continue
+  [[ "$name" == "$current" ]] && continue
+  if (( ${#keep[@]} < RETAINED )); then
+    keep+=("$name")
+  fi
+done
+
+for name in "${ordered[@]}"; do
+  [[ "$name" =~ ^acad-ia-functions-source-[0-9a-f]{32}$ ]] || continue
+  retained=false
+  for kept in "${keep[@]}"; do
+    if [[ "$name" == "$kept" ]]; then
+      retained=true
+      break
+    fi
+  done
+  if [[ "$retained" == false ]]; then
+    kubectl delete configmap "$name" --namespace "$AKS_NAMESPACE"
+  fi
+done

--- a/deploy/scripts/publish-functions-source.sh
+++ b/deploy/scripts/publish-functions-source.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AKS_NAMESPACE:?AKS_NAMESPACE is required}"
+: "${FUNCTIONS_SOURCE_REVISION:?FUNCTIONS_SOURCE_REVISION is required}"
+
+readonly PVC_NAME="${FUNCTIONS_SOURCE_PVC:-acad-ia-backend-supabase-snippets}"
+readonly CONFIG_MAP_NAME="acad-ia-functions-source-${FUNCTIONS_SOURCE_REVISION:0:32}"
+
+if [[ ! "$FUNCTIONS_SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'FUNCTIONS_SOURCE_REVISION must be a full lowercase Git SHA.\n' >&2
+  exit 1
+fi
+
+kubectl get namespace "$AKS_NAMESPACE" >/dev/null
+kubectl get pvc "$PVC_NAME" --namespace "$AKS_NAMESPACE" >/dev/null
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+bundle="$work_dir/functions.tar.gz"
+FUNCTIONS_BUNDLE_MAX_BYTES=900000 \
+  GITHUB_OUTPUT='' \
+  bash deploy/scripts/package-functions-source.sh "$FUNCTIONS_SOURCE_REVISION" "$bundle" \
+  >/dev/null
+
+bundle_sha="$(sha256sum "$bundle" | cut -d ' ' -f 1)"
+bundle_size="$(stat -c '%s' "$bundle")"
+
+if kubectl get configmap "$CONFIG_MAP_NAME" --namespace "$AKS_NAMESPACE" >/dev/null 2>&1; then
+  existing_sha="$(kubectl get configmap "$CONFIG_MAP_NAME" \
+    --namespace "$AKS_NAMESPACE" \
+    -o jsonpath='{.metadata.annotations.acad-ia\.ulsa\.mx/bundle-sha256}')"
+  if [[ "$existing_sha" != "$bundle_sha" ]]; then
+    printf 'Existing immutable ConfigMap %s has an unexpected digest.\n' "$CONFIG_MAP_NAME" >&2
+    exit 1
+  fi
+else
+  kubectl create configmap "$CONFIG_MAP_NAME" \
+    --namespace "$AKS_NAMESPACE" \
+    --from-file="functions.tar.gz=$bundle" \
+    --dry-run=client \
+    -o json |
+    jq \
+      --arg revision "$FUNCTIONS_SOURCE_REVISION" \
+      --arg sha "$bundle_sha" \
+      '.immutable = true
+       | .metadata.labels["app.kubernetes.io/name"] = "acad-ia-backend"
+       | .metadata.labels["app.kubernetes.io/component"] = "functions-source"
+       | .metadata.labels["app.kubernetes.io/managed-by"] = "github-actions"
+       | .metadata.annotations["acad-ia.ulsa.mx/source-revision"] = $revision
+       | .metadata.annotations["acad-ia.ulsa.mx/bundle-sha256"] = $sha' |
+    kubectl create -f - >/dev/null
+fi
+
+previous_revision="$(kubectl get deployment acad-ia-functions \
+  --namespace "$AKS_NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="FUNCTIONS_SOURCE_REVISION")].value}' \
+  2>/dev/null || true)"
+if [[ ! "$previous_revision" =~ ^[0-9a-f]{40}$ ]]; then
+  previous_revision=''
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'config_map_name=%s\n' "$CONFIG_MAP_NAME"
+    printf 'bundle_sha256=%s\n' "$bundle_sha"
+    printf 'bundle_bytes=%s\n' "$bundle_size"
+    printf 'previous_revision=%s\n' "$previous_revision"
+  } >> "$GITHUB_OUTPUT"
+else
+  printf 'config_map_name=%s\nbundle_sha256=%s\nbundle_bytes=%s\nprevious_revision=%s\n' \
+    "$CONFIG_MAP_NAME" "$bundle_sha" "$bundle_size" "$previous_revision"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -389,7 +389,7 @@ services:
       CRYPTO_KEY: ${PG_META_CRYPTO_KEY}
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.74.0
+    image: supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c
     restart: unless-stopped
     healthcheck:
       test: ['CMD-SHELL', "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]

--- a/supabase/functions/.dockerignore
+++ b/supabase/functions/.dockerignore
@@ -1,3 +1,0 @@
-**/node_modules
-**/.env
-tests

--- a/supabase/functions/Dockerfile
+++ b/supabase/functions/Dockerfile
@@ -1,5 +1,0 @@
-FROM supabase/edge-runtime:v1.74.0
-
-COPY . /home/deno/functions
-
-CMD ["start", "--main-service", "/home/deno/functions/main"]


### PR DESCRIPTION
## Resumen
- usa supabase/edge-runtime:v1.74.3 fijado por digest
- elimina el build/push de la imagen cad-ia-functions
- publica un bundle determinista de Functions en un ConfigMap inmutable
- instala y conserva cinco revisiones en el PVC de snippets existente
- monta la misma revisión en Edge Runtime y Studio
- elimina el repositorio ACR legado después del rollout y webhook verificados

## Infraestructura
No crea nodos, discos, registros ni servicios Azure nuevos. Reutiliza el PVC existente y reduce artefactos de ACR.

## Validación
- 176 pruebas de Edge Functions
- pruebas del generador de secretos
- Helm lint/template
- Job de instalación y poda ejecutado con Alpine
- smoke test del runtime v1.74.3 por digest (webhook HTTP 400 sin firma)
- actionlint, ShellCheck y Docker Compose config
- builds de migrator y backup

## Despliegue
Este PR no despliega Azure. El workflow de PR sólo valida; producción requiere merge/ejecución posterior.