### PR TITLE
fix(ci): remove recurring ACR repository deletion

### DIFF
--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -428,38 +428,6 @@ jobs:
         shell: bash
         run: bash deploy/scripts/prune-functions-source-configmaps.sh
 
-      - name: Remove obsolete Functions image repository
-        env:
-          ACR_NAME: ${{ vars.ACR_NAME }}
-          AKS_NAMESPACE: ${{ vars.AKS_NAMESPACE }}
-        shell: bash
-        run: |
-          live_references="$(kubectl get deployment \
-            --namespace "$AKS_NAMESPACE" \
-            -o json | jq -r '
-              .items[]
-              | (.spec.template.spec.containers[]?.image,
-                 .spec.template.spec.initContainers[]?.image,
-                 .spec.template.spec.volumes[]?.image?.reference)
-              | select(. != null)')"
-          if grep -Fq '/acad-ia-functions:' <<<"$live_references"; then
-            echo '::error::A live Deployment still references acad-ia-functions; refusing to remove the repository.'
-            exit 1
-          fi
-
-          if az acr repository show \
-            --name "$ACR_NAME" \
-            --repository acad-ia-functions \
-            --output none \
-            --only-show-errors 2>/dev/null; then
-            az acr repository delete \
-              --name "$ACR_NAME" \
-              --repository acad-ia-functions \
-              --yes \
-              --output none \
-              --only-show-errors
-          fi
-
       - name: Collect deployment diagnostics
         if: ${{ failure() || cancelled() }}
         env:

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -218,11 +218,12 @@ Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.
 No se copia código a un pod o nodo con `scp`: esos sistemas de archivos son
 efímeros en AKS. El equivalente reproducible del volumen recomendado por
-Supabase es una revisión inmutable en el PVC existente. Tras comprobar el
-webhook y verificar que no quedan referencias vivas, el workflow elimina por
-completo el repositorio ACR legado `acad-ia-functions`. La revisión Helm previa
-basada en esa imagen deja de ser un rollback válido; para volver atrás se
-redepliega el commit deseado mediante este mismo workflow.
+Supabase es una revisión inmutable en el PVC existente. El repositorio ACR
+legado `acad-ia-functions` se eliminó como una operación única después del
+primer rollout verificado; el workflow recurrente no elimina repositorios de
+contenedores. La revisión Helm previa basada en esa imagen deja de ser un
+rollback válido; para volver atrás se redepliega el commit deseado mediante
+este mismo workflow.
 
 El Job de Helm ejecuta `supabase migration up --include-all` y después el seed.
 Antes de migrar espera hasta diez minutos a que Postgres esté disponible; esto


### PR DESCRIPTION
## Corrección
- elimina del workflow recurrente el borrado de acad-ia-functions en ACR
- documenta que la eliminación ya realizada fue una operación única
- conserva únicamente la poda de revisiones de código de Functions dentro de Kubernetes

## Validación
- actionlint sobre .github/workflows/backend-aks.yml
- git diff --check

Esta corrección no crea, amplía ni reprovisiona infraestructura de Azure.