### PR TITLE
Optimize GitHub Actions and fix Studio manifest auth

### DIFF
--- a/.github/actions/detect-supabase-changes/action.yml
+++ b/.github/actions/detect-supabase-changes/action.yml
@@ -1,5 +1,5 @@
 name: Detect Supabase changes
-description: Reports whether a pull request changes files under supabase/.
+description: Classifies managed-Supabase runtime, database, and Edge Function changes.
 
 inputs:
   github-token:
@@ -8,8 +8,14 @@ inputs:
 
 outputs:
   changed:
-    description: Whether the pull request changes supabase/.
+    description: Whether a managed Supabase preview must be reconciled.
     value: ${{ steps.detect.outputs.changed }}
+  database:
+    description: Whether database behavior or pgTAP tests changed.
+    value: ${{ steps.detect.outputs.database }}
+  functions:
+    description: Whether Edge Function behavior or unit tests changed.
+    value: ${{ steps.detect.outputs.functions }}
 
 runs:
   using: composite
@@ -22,6 +28,8 @@ runs:
           if (context.eventName !== 'pull_request') {
             core.info('Non-PR run: Supabase changes are assumed.')
             core.setOutput('changed', 'true')
+            core.setOutput('database', 'true')
+            core.setOutput('functions', 'true')
             return
           }
 
@@ -31,19 +39,41 @@ runs:
             pull_number: context.issue.number,
             per_page: 100,
           })
-          const touchesSupabase = (path) => path?.startsWith('supabase/')
-          const matchingFiles = files.filter(
-            (file) =>
-              touchesSupabase(file.filename) ||
-              touchesSupabase(file.previous_filename),
+          const paths = new Set(
+            files.flatMap((file) =>
+              [file.filename, file.previous_filename].filter(Boolean),
+            ),
           )
-          const changed = matchingFiles.length > 0
+          const databasePatterns = [
+            /^supabase\/config\.toml$/,
+            /^supabase\/migrations\//,
+            /^supabase\/tests\/database\//,
+            /^supabase\/db\//,
+            /^supabase\/(seed(?:\.stage)?|schema)\.sql$/,
+          ]
+          const functionPatterns = [
+            /^supabase\/config\.toml$/,
+            /^supabase\/functions\//,
+          ]
+          const deployablePatterns = [
+            /^supabase\/config\.toml$/,
+            /^supabase\/migrations\//,
+            /^supabase\/functions\//,
+            /^supabase\/template-assets\//,
+            /^supabase\/(seed(?:\.stage)?|schema)\.sql$/,
+          ]
+          const matching = (patterns) =>
+            [...paths].filter((path) =>
+              patterns.some((pattern) => pattern.test(path)),
+            )
 
-          core.info(
-            changed
-              ? `Supabase changes detected in: ${matchingFiles
-                  .map((file) => file.filename)
-                  .join(', ')}`
-              : 'No files under supabase/ changed.',
-          )
-          core.setOutput('changed', String(changed))
+          const deployable = matching(deployablePatterns)
+          const database = matching(databasePatterns)
+          const functions = matching(functionPatterns)
+
+          core.info(`Managed Supabase runtime: ${deployable.join(', ') || '(unchanged)'}`)
+          core.info(`Database scope: ${database.join(', ') || '(unchanged)'}`)
+          core.info(`Edge Functions scope: ${functions.join(', ') || '(unchanged)'}`)
+          core.setOutput('changed', String(deployable.length > 0))
+          core.setOutput('database', String(database.length > 0))
+          core.setOutput('functions', String(functions.length > 0))

--- a/.github/actions/update-azure-preview-comment/action.yml
+++ b/.github/actions/update-azure-preview-comment/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Supabase project ref when state is ready.
     required: false
   supabase-source:
-    description: Supabase target source (preview or production) when state is ready.
+    description: Supabase target source (preview, hosted-qa, or production) when state is ready.
     required: false
     default: preview
   commit-sha:
@@ -75,17 +75,21 @@ runs:
             if (!/^[a-z0-9]{20}$/.test(projectRef)) {
               throw new Error('preview-project-ref is invalid')
             }
-            if (!['preview', 'production'].includes(supabaseSource)) {
-              throw new Error('supabase-source must be preview or production')
+            const supabaseLabels = {
+              preview: 'branch temporal',
+              'hosted-qa': 'proyecto hospedado de QA',
+              production: 'producción compartida',
+            }
+            if (!(supabaseSource in supabaseLabels)) {
+              throw new Error(
+                'supabase-source must be preview, hosted-qa, or production',
+              )
             }
             if (!/^[a-f0-9]{40}$/.test(commitSha)) {
               throw new Error('commit-sha is invalid')
             }
 
-            const supabaseLabel =
-              supabaseSource === 'production'
-                ? 'producción compartida'
-                : 'branch temporal'
+            const supabaseLabel = supabaseLabels[supabaseSource]
 
             body = `${marker}
           ### Vista previa de Azure lista

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -16,19 +16,20 @@ permissions:
   pull-requests: write
 
 jobs:
-  prepare_supabase:
-    name: Activate selected Supabase
+  deploy_preview:
+    name: Deploy preview with selected Supabase
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: preview
     concurrency:
       group: supabase-preview-state-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    outputs:
-      changed: ${{ steps.supabase-changes.outputs.changed }}
+    env:
+      AZURE_PREVIEW_URL: https://victorious-bay-0ca0aae10-${{ github.event.pull_request.number }}.centralus.3.azurestaticapps.net
 
     steps:
+      # Run privileged branch-management actions from the trusted base revision.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -55,34 +56,9 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-  deploy_preview:
-    name: Deploy preview with selected Supabase
-    needs: prepare_supabase
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: preview
-    env:
-      AZURE_PREVIEW_URL: https://victorious-bay-0ca0aae10-${{ github.event.pull_request.number }}.centralus.3.azurestaticapps.net
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - uses: supabase/setup-cli@v3
-        if: needs.prepare_supabase.outputs.changed == 'true'
-        with:
-          version: 2.115.0
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Resolve Supabase preview branch
         id: supabase-preview
-        if: needs.prepare_supabase.outputs.changed == 'true'
+        if: steps.supabase-changes.outputs.changed == 'true'
         uses: ./.github/actions/resolve-supabase-preview
         with:
           branch-name: ${{ github.head_ref }}
@@ -91,9 +67,19 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      # Build the application from the pull request after privileged setup.
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Use hosted QA Supabase
         id: hosted_qa_supabase
-        if: needs.prepare_supabase.outputs.changed != 'true'
+        if: steps.supabase-changes.outputs.changed != 'true'
         env:
           HOSTED_QA_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
           HOSTED_QA_SUPABASE_ANON_KEY: ${{ vars.VITE_SUPABASE_ANON_KEY }}
@@ -126,7 +112,7 @@ jobs:
       - name: Select Supabase target
         id: supabase-target
         env:
-          SUPABASE_CHANGED: ${{ needs.prepare_supabase.outputs.changed }}
+          SUPABASE_CHANGED: ${{ steps.supabase-changes.outputs.changed }}
           PREVIEW_AVAILABLE: ${{ steps.supabase-preview.outputs.available }}
           PREVIEW_REASON: ${{ steps.supabase-preview.outputs.reason }}
           HOSTED_QA_AVAILABLE: ${{ steps.hosted_qa_supabase.outputs.available }}
@@ -256,7 +242,7 @@ jobs:
           run-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Close stale Azure preview
-        if: needs.prepare_supabase.outputs.changed == 'true' && steps.supabase-target.outputs.available != 'true'
+        if: steps.supabase-changes.outputs.changed == 'true' && steps.supabase-target.outputs.available != 'true'
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_SWA_DEPLOYMENT_TOKEN }}
@@ -264,7 +250,7 @@ jobs:
           action: close
 
       - name: Report unavailable Supabase branch
-        if: needs.prepare_supabase.outputs.changed == 'true' && steps.supabase-target.outputs.available != 'true'
+        if: steps.supabase-changes.outputs.changed == 'true' && steps.supabase-target.outputs.available != 'true'
         env:
           REASON: ${{ steps.supabase-target.outputs.reason }}
         run: |

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -133,13 +133,17 @@ jobs:
         shell: bash
         run: |
           if [[ "$SUPABASE_CHANGED" == 'true' ]]; then
-            echo "available=${PREVIEW_AVAILABLE:-false}" >> "$GITHUB_OUTPUT"
-            echo 'source=preview' >> "$GITHUB_OUTPUT"
-            echo "reason=${PREVIEW_REASON:-preview-unavailable}" >> "$GITHUB_OUTPUT"
+            {
+              echo "available=${PREVIEW_AVAILABLE:-false}"
+              echo 'source=preview'
+              echo "reason=${PREVIEW_REASON:-preview-unavailable}"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "available=${HOSTED_QA_AVAILABLE:-false}" >> "$GITHUB_OUTPUT"
-            echo 'source=hosted-qa' >> "$GITHUB_OUTPUT"
-            echo 'reason=resolved-hosted-qa' >> "$GITHUB_OUTPUT"
+            {
+              echo "available=${HOSTED_QA_AVAILABLE:-false}"
+              echo 'source=hosted-qa'
+              echo 'reason=resolved-hosted-qa'
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Configure preview function secrets

--- a/.github/workflows/azure-static-web-apps-production.yml
+++ b/.github/workflows/azure-static-web-apps-production.yml
@@ -1,10 +1,12 @@
 name: Deploy to Azure Static Web Apps
 
 on:
-  workflow_run:
-    workflows: [Backend AKS]
-    types: [completed]
-    branches: [main]
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: Commit whose frontend will be published after backend reconciliation
+        required: true
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -17,14 +19,13 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: production
 
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ inputs.commit_sha || github.sha }}
 
       - name: Azure login with OIDC
         uses: azure/login@v2
@@ -56,7 +57,8 @@ jobs:
             --output none \
             --only-show-errors
           export VITE_SUPABASE_URL="https://${AKS_BACKEND_HOST}"
-          export VITE_SUPABASE_ANON_KEY="$(<"$work_dir/publishable-key")"
+          VITE_SUPABASE_ANON_KEY="$(<"$work_dir/publishable-key")"
+          export VITE_SUPABASE_ANON_KEY
           bunx --bun vite build
 
       - uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -137,10 +137,12 @@ jobs:
         run: bash deploy/scripts/key-vault-secrets.test.sh
 
       - uses: denoland/setup-deno@v2
+        if: github.event_name != 'pull_request'
         with:
           deno-version: v2.9.5
 
       - name: Cache Deno dependencies
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v6
         with:
           path: ~/.cache/deno
@@ -149,6 +151,7 @@ jobs:
             ${{ runner.os }}-deno-2.9.5-
 
       - name: Test Edge Functions
+        if: github.event_name != 'pull_request'
         run: deno test --node-modules-dir=none --allow-env --allow-read --allow-sys=umask supabase/functions/tests/unit
 
       - uses: azure/setup-helm@v4

--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/rotate-backend-secrets.yml'
       - '.github/workflows/publish-backend-secrets-vaultwarden.yml'
       - '.github/workflows/onboard-portainer-aks.yml'
-  # Run for every main commit so the frontend workflow can wait for this one.
+  # Orchestrate backend and production-frontend releases from one change detector.
   push:
     branches: [main]
   workflow_dispatch:
@@ -25,10 +25,12 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: read
 
 concurrency:
   group: backend-aks-${{ github.ref }}
-  cancel-in-progress: false
+  # Superseded PR validations are disposable; production deployments are not.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CHART_PATH: deploy/helm/acad-ia-backend
@@ -40,41 +42,85 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.detect.outputs.backend }}
+      frontend: ${{ steps.detect.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
       - name: Detect deployable backend changes
         id: detect
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        shell: bash
-        run: |
-          if [[ "$EVENT_NAME" == 'workflow_dispatch' ]]; then
-            echo 'backend=true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('backend', 'true')
+              // Preserve the explicit full-release behavior of manual runs.
+              core.setOutput('frontend', 'true')
+              return
+            }
 
-          base="$BEFORE_SHA"
-          if [[ "$EVENT_NAME" == 'pull_request' ]]; then
-            base="$PR_BASE_SHA"
-          elif [[ -z "$base" || "$base" =~ ^0+$ ]]; then
-            base="${GITHUB_SHA}^"
-          fi
+            let files
+            if (context.eventName === 'pull_request') {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              })
+            } else {
+              const before = context.payload.before
+              const head = context.sha
+              if (!before || /^0+$/.test(before)) {
+                const commit = await github.rest.repos.getCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: head,
+                })
+                files = commit.data.files ?? []
+              } else {
+                const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  basehead: `${before}...${head}`,
+                  per_page: 100,
+                })
+                files = comparison.data.files ?? []
+              }
+            }
 
-          changed=false
-          while IFS= read -r path; do
-            case "$path" in
-              supabase/*|deploy/*|docker-compose*.yml|.env.example|.github/workflows/backend-aks.yml|.github/workflows/rotate-backend-secrets.yml|.github/workflows/publish-backend-secrets-vaultwarden.yml|.github/workflows/onboard-portainer-aks.yml)
-                changed=true
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "$base" "$GITHUB_SHA")
-          echo "backend=$changed" >> "$GITHUB_OUTPUT"
+            // GitHub caps compare responses at 300 changed files. A truncated
+            // release must deploy conservatively instead of skipping work.
+            if (context.eventName === 'push' && files.length >= 300) {
+              core.warning('The comparison reached GitHub\'s 300-file limit; deploying both targets.')
+              core.setOutput('backend', 'true')
+              core.setOutput('frontend', 'true')
+              return
+            }
+
+            const paths = new Set(
+              files.flatMap((file) =>
+                [file.filename, file.previous_filename].filter(Boolean),
+              ),
+            )
+            const backendPatterns = [
+              /^supabase\//,
+              /^deploy\//,
+              /^docker-compose.*\.yml$/,
+              /^\.env\.example$/,
+              /^\.github\/workflows\/(backend-aks|rotate-backend-secrets|publish-backend-secrets-vaultwarden|onboard-portainer-aks)\.yml$/,
+            ]
+            const frontendPatterns = [
+              /^src\//,
+              /^public\//,
+              /^api\//,
+              /^(index\.html|package\.json|bun\.lock|vite\.config\.ts|tsconfig.*\.json|eslint\.config\.js|prettier\.config\.js|components\.json)$/,
+              /^\.github\/workflows\/azure-static-web-apps-production\.yml$/,
+            ]
+            const matches = (patterns) =>
+              [...paths].some((path) => patterns.some((pattern) => pattern.test(path)))
+
+            const backend = matches(backendPatterns)
+            const frontend = matches(frontendPatterns)
+            core.info(`Changed paths: ${[...paths].join(', ') || '(none)'}`)
+            core.setOutput('backend', String(backend))
+            core.setOutput('frontend', String(frontend))
 
   verify:
     name: Verify backend package
@@ -87,9 +133,20 @@ jobs:
       - name: Test secret generator
         run: node --test deploy/scripts/generate-supabase-secrets.test.mjs
 
+      - name: Test Key Vault synchronization helpers
+        run: bash deploy/scripts/key-vault-secrets.test.sh
+
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.9.5
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/deno
+          key: ${{ runner.os }}-deno-2.9.5-${{ hashFiles('deno.lock', 'supabase/functions/**/deno.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-2.9.5-
 
       - name: Test Edge Functions
         run: deno test --node-modules-dir=none --allow-env --allow-read --allow-sys=umask supabase/functions/tests/unit
@@ -122,12 +179,19 @@ jobs:
           test "$(grep --count 'claimName: acad-ia-backend-supabase-db-standard-v1' /tmp/acad-ia-backend.yaml)" = 1
 
       - uses: docker/setup-buildx-action@v3
+        if: github.event_name == 'pull_request'
 
       - name: Validate container builds
+        if: github.event_name == 'pull_request'
         uses: docker/bake-action@v6
         with:
           push: false
           files: deploy/docker-bake.hcl
+          set: |
+            migrator.cache-from=type=gha,scope=acad-ia-migrator
+            migrator.cache-to=type=gha,scope=acad-ia-migrator,mode=max
+            backup.cache-from=type=gha,scope=acad-ia-backup
+            backup.cache-to=type=gha,scope=acad-ia-backup,mode=max
 
   deploy:
     name: Deploy production backend
@@ -157,7 +221,11 @@ jobs:
           files: deploy/docker-bake.hcl
           set: |
             migrator.tags=${{ vars.ACR_LOGIN_SERVER }}/acad-ia-migrator:${{ github.sha }}
+            migrator.cache-from=type=gha,scope=acad-ia-migrator
+            migrator.cache-to=type=gha,scope=acad-ia-migrator,mode=max
             backup.tags=${{ vars.ACR_LOGIN_SERVER }}/acad-ia-backup:${{ github.sha }}
+            backup.cache-from=type=gha,scope=acad-ia-backup
+            backup.cache-to=type=gha,scope=acad-ia-backup,mode=max
 
       - name: Bootstrap and synchronize Azure Key Vault
         env:
@@ -292,15 +360,27 @@ jobs:
       - name: Reconcile certificate management
         shell: bash
         run: |
-          helm upgrade --install cert-manager \
-            oci://quay.io/jetstack/charts/cert-manager \
-            --version v1.21.1 \
-            --namespace cert-manager \
-            --create-namespace \
-            --set crds.enabled=true \
-            --atomic \
-            --wait \
-            --timeout 10m
+          desired_chart='cert-manager-v1.21.1'
+          installed_chart="$(
+            helm list \
+              --namespace cert-manager \
+              --filter '^cert-manager$' \
+              --output json 2>/dev/null |
+              jq --raw-output '.[0].chart // empty'
+          )"
+          if [[ "$installed_chart" != "$desired_chart" ]]; then
+            helm upgrade --install cert-manager \
+              oci://quay.io/jetstack/charts/cert-manager \
+              --version v1.21.1 \
+              --namespace cert-manager \
+              --create-namespace \
+              --set crds.enabled=true \
+              --atomic \
+              --wait \
+              --timeout 10m
+          else
+            echo "cert-manager already uses $desired_chart; skipping the unchanged Helm release."
+          fi
           kubectl apply -f deploy/aks/cert-manager-clusterissuer.yaml
           kubectl wait --for=condition=Ready clusterissuer/letsencrypt-production \
             --timeout=5m
@@ -439,3 +519,16 @@ jobs:
           kubectl get nodes -o wide || true
           kubectl get pods,jobs,pvc,ingress --namespace "$AKS_NAMESPACE" -o wide || true
           kubectl get events --namespace "$AKS_NAMESPACE" --sort-by=.lastTimestamp | tail -n 80 || true
+
+  frontend:
+    name: Deploy production frontend
+    needs: [changes, deploy]
+    if: >-
+      always() &&
+      github.event_name != 'pull_request' &&
+      needs.changes.outputs.frontend == 'true' &&
+      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
+    uses: ./.github/workflows/azure-static-web-apps-production.yml
+    with:
+      commit_sha: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,19 @@ name: Deploy testing site to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'api/**'
+      - 'index.html'
+      - 'package.json'
+      - 'bun.lock'
+      - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'eslint.config.js'
+      - 'prettier.config.js'
+      - 'components.json'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -10,7 +23,7 @@ permissions:
 
 concurrency:
   group: github-pages-testing
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -20,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/supabase-update.yaml
+++ b/.github/workflows/supabase-update.yaml
@@ -1,8 +1,6 @@
-name: backup-database
+name: Export linked Supabase snapshot
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,8 @@ jobs:
     name: Detect Supabase changes
     runs-on: ubuntu-latest
     outputs:
-      supabase: ${{ steps.supabase.outputs.changed }}
+      database: ${{ steps.supabase.outputs.database }}
+      functions: ${{ steps.supabase.outputs.functions }}
 
     steps:
       - uses: actions/checkout@v7
@@ -80,7 +81,7 @@ jobs:
   database:
     name: Supabase database tests
     needs: changes
-    if: needs.changes.outputs.supabase == 'true'
+    if: needs.changes.outputs.database == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -102,7 +103,7 @@ jobs:
   edge-functions:
     name: Supabase Edge Function unit tests
     needs: changes
-    if: needs.changes.outputs.supabase == 'true'
+    if: needs.changes.outputs.functions == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
 
   frontend:
     name: Frontend Bun tests
-    needs: changes
     runs-on: ubuntu-latest
     env:
       VITE_SUPABASE_URL: http://127.0.0.1:54321
@@ -50,11 +49,24 @@ jobs:
       - name: Design spacing contract
         run: bun run design:spacing
 
-      - name: Lint
-        run: bun run lint
+      - name: Lint and typecheck
+        shell: bash
+        run: |
+          set +e
+          bun run lint &
+          lint_pid=$!
+          bun run typecheck &
+          typecheck_pid=$!
 
-      - name: Typecheck
-        run: bun run typecheck
+          wait "$lint_pid"
+          lint_status=$?
+          wait "$typecheck_pid"
+          typecheck_status=$?
+
+          if (( lint_status != 0 || typecheck_status != 0 )); then
+            echo "::error::Lint exited with $lint_status; typecheck exited with $typecheck_status."
+            exit 1
+          fi
 
       - name: Unit tests with coverage
         run: bun run test:coverage
@@ -98,7 +110,15 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: latest
+          deno-version: v2.9.5
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/deno
+          key: ${{ runner.os }}-deno-2.9.5-${{ hashFiles('deno.lock', 'supabase/functions/**/deno.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-2.9.5-
 
       - name: Run Deno unit tests
         run: deno test --node-modules-dir=none --allow-env --allow-read --allow-sys=umask supabase/functions/tests/unit

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -237,9 +237,12 @@ y ACR conserva sólo los artefactos desplegables.
 
 Las pruebas de frontend comienzan en paralelo con la detección de cambios de
 Supabase; lint y typecheck también comparten tiempo de ejecución y conservan
-resultados independientes. GitHub Pages y el frontend productivo se omiten en
-commits que no modifican sus entradas de compilación, y los runs obsoletos de
-PR, staging y testing se cancelan a favor del commit más reciente.
+resultados independientes. Las pruebas de base, las de Edge Functions y la
+creación de una branch hospedada se activan por sus entradas reales, no por
+archivos auxiliares de los contenedores self-hosted. GitHub Pages y el frontend
+productivo se omiten en commits que no modifican sus entradas de compilación,
+y los runs obsoletos de PR, staging y testing se cancelan a favor del commit
+más reciente.
 
 Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -2,9 +2,11 @@
 
 Este paquete prepara Supabase self-hosted para producción en AKS sin desplegar
 el frontend. GitHub Pages es el sitio de pruebas; los sitios temporales de Azure
-Static Web Apps creados por pull request son staging y permanecen intactos; el
-sitio productivo de Azure se compila contra el hostname de AKS sólo después de
-que el workflow del backend termina correctamente.
+Static Web Apps creados por pull request son staging y permanecen intactos. Un
+único workflow de release detecta qué cambió: reconcilia AKS sólo para cambios
+del backend y llama al workflow reutilizable del sitio productivo únicamente
+para cambios del frontend. Si ambos cambiaron, el frontend espera a que AKS
+termine correctamente.
 
 La instancia administrada de Supabase se conserva únicamente para testing,
 staging y QA. Producción usa el Postgres, Auth, REST, Realtime, Storage y Edge
@@ -39,6 +41,12 @@ No use el asistente de Azure Portal que genera un Dockerfile Node y un Service
 `LoadBalancer` en el puerto 3000. Supabase es un conjunto de servicios; sólo
 Envoy queda detrás del Ingress. Postgres, Auth, REST, Realtime, Storage,
 Functions, Meta, Studio y Supavisor permanecen privados como `ClusterIP`.
+
+El Dashboard sigue protegido por Basic Auth en Envoy. La única excepción
+estática adicional es la ruta exacta `/favicon/manifest.json`: los navegadores
+solicitan el Web App Manifest sin reenviar esas credenciales y Studio lo
+necesita para representar correctamente sus páginas. No se abre el prefijo
+`/favicon/` ni ninguna API de Studio.
 
 ## Webhook de OpenAI
 
@@ -152,6 +160,11 @@ hot-fix. El workflow del backend hace lo siguiente:
 3. Copia desde GitHub únicamente los secretos externos ausentes.
 4. Sincroniza Key Vault al Secret `acad-ia-backend-secrets` justo antes de Helm.
 
+La sincronización obtiene el inventario de Key Vault una sola vez y descarga
+los valores requeridos en paralelo con concurrencia acotada. Los secretos se
+mantienen en archivos con modo `0600`, nunca se incluyen en la salida del job y
+un fallo parcial impide continuar el despliegue.
+
 Un commit normal nunca rota credenciales y tampoco revierte un hot-fix de Key
 Vault. Para reemplazar secretos externos desde GitHub, ejecute manualmente
 `Backend AKS` con `sync_external_secrets=true`.
@@ -170,7 +183,9 @@ valor editado accidentalmente en el gestor de contraseñas no cambia un runtime
 productivo ni crea dos fuentes de verdad. Un hot-fix se hace en Key Vault y
 después se publica la nueva instantánea. El script usa archivos temporales con
 permisos restrictivos, nunca imprime valores y bloquea/cierra la sesión de `bw`
-al terminar.
+al terminar. Comparte la descarga paralela y acotada de Key Vault con el
+despliegue, pero conserva una sola actualización atómica del item de
+Vaultwarden.
 
 La autenticación de CI usa `bw login --apikey` y un desbloqueo explícito. Los
 tres valores de autenticación se guardan como secrets del environment
@@ -213,6 +228,18 @@ GitHub Actions construye dos imágenes:
   seed idempotente.
 - `acad-ia-backup`: cliente Postgres 17, `rclone` y el procedimiento de
   respaldo.
+
+Cada imagen usa un contexto Docker mínimo y una caché BuildKit de GitHub
+independiente. En pull requests se construyen sin publicar para validar los
+Dockerfiles; en `main` se construyen y publican una sola vez, sin repetir antes
+la misma compilación. Las capas reutilizables permanecen en la caché de Actions
+y ACR conserva sólo los artefactos desplegables.
+
+Las pruebas de frontend comienzan en paralelo con la detección de cambios de
+Supabase; lint y typecheck también comparten tiempo de ejecución y conservan
+resultados independientes. GitHub Pages y el frontend productivo se omiten en
+commits que no modifican sus entradas de compilación, y los runs obsoletos de
+PR, staging y testing se cancelan a favor del commit más reciente.
 
 Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.
@@ -277,8 +304,9 @@ entre base y objetos. Para un RPO estricto, complemente este respaldo lógico co
 Azure Backup/snapshots coordinados y pruebe restauraciones periódicas en un
 namespace aislado.
 
-El workflow histórico `.github/workflows/supabase-update.yaml` respalda el
-proyecto administrado de preview; no cubre Postgres ni Storage de AKS.
+El workflow histórico `.github/workflows/supabase-update.yaml` exporta
+manualmente una instantánea del proyecto administrado de preview; ya no se
+ejecuta en cada push. No cubre Postgres ni Storage de AKS.
 
 ## Preparación previa del clúster
 
@@ -288,7 +316,9 @@ Antes del primer despliegue deben existir:
 2. Ingress Web App Routing. El workflow instala cert-manager y reconcilia el
    `ClusterIssuer` de Let's Encrypt antes del chart de la aplicación. También
    mantiene el NGINX administrado en una réplica base y hasta dos réplicas con
-   el perfil `steady`.
+   el perfil `steady`. Cuando ya está instalada exactamente la versión fijada
+   de cert-manager, omite el `helm upgrade` inalterado y sólo verifica el
+   `ClusterIssuer`.
 3. Azure Key Vault con RBAC para la identidad federada de GitHub.
 4. Azure Monitor/Container Insights y Managed Prometheus según el estándar de
    la plataforma.

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -242,7 +242,9 @@ creación de una branch hospedada se activan por sus entradas reales, no por
 archivos auxiliares de los contenedores self-hosted. GitHub Pages y el frontend
 productivo se omiten en commits que no modifican sus entradas de compilación,
 y los runs obsoletos de PR, staging y testing se cancelan a favor del commit
-más reciente.
+más reciente. El staging de Azure activa Supabase y compila el frontend en un
+solo job, sin reservar dos runners de forma serial; las operaciones con el
+token de Supabase siguen ejecutándose desde la revisión confiable de `main`.
 
 Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.

--- a/deploy/helm/acad-ia-backend/files/envoy/lds.template.yaml
+++ b/deploy/helm/acad-ia-backend/files/envoy/lds.template.yaml
@@ -537,6 +537,33 @@ resources:
                             expose_headers: "*"
                             max_age: "3600"
 
+                      # Web app manifests are fetched without HTTP Basic credentials,
+                      # even on the same origin. Keep only this static Studio asset
+                      # public so authenticated Dashboard pages do not emit a 401.
+                      - name: studio-manifest-public
+                        match:
+                          path: /favicon/manifest.json
+                        route:
+                          cluster: studio
+                          timeout: 30s
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+
                       - match:
                           prefix: /api/mcp
                         route:

--- a/deploy/scripts/key-vault-secrets.sh
+++ b/deploy/scripts/key-vault-secrets.sh
@@ -53,13 +53,31 @@ readonly SECRET_MAP=(
   'rustfs-secret-access-key:RUSTFS_SECRET_ACCESS_KEY'
 )
 
+declare -A KEY_VAULT_SECRET_NAMES=()
+KEY_VAULT_SECRET_CACHE_LOADED=false
+
+load_key_vault_secret_names() {
+  if [[ "$KEY_VAULT_SECRET_CACHE_LOADED" == 'true' ]]; then
+    return 0
+  fi
+
+  local names name
+  names="$(
+    az keyvault secret list \
+      --vault-name "$AZURE_KEY_VAULT_NAME" \
+      --query '[].name' \
+      --output tsv \
+      --only-show-errors
+  )"
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && KEY_VAULT_SECRET_NAMES["$name"]=1
+  done <<< "$names"
+  KEY_VAULT_SECRET_CACHE_LOADED=true
+}
+
 secret_exists() {
-  az keyvault secret show \
-    --vault-name "$AZURE_KEY_VAULT_NAME" \
-    --name "$1" \
-    --query id \
-    --output tsv \
-    --only-show-errors >/dev/null 2>&1
+  load_key_vault_secret_names
+  [[ -n "${KEY_VAULT_SECRET_NAMES[$1]+present}" ]]
 }
 
 set_secret_file() {
@@ -72,6 +90,7 @@ set_secret_file() {
     --encoding utf-8 \
     --output none \
     --only-show-errors
+  KEY_VAULT_SECRET_NAMES["$name"]=1
 }
 
 set_secret_value() {
@@ -110,29 +129,85 @@ store_json_secrets() {
   done < <(jq --raw-output 'keys[]' "$json_file")
 }
 
+wait_for_secret_downloads() {
+  local failed=0 pid
+  for pid in "$@"; do
+    if ! wait "$pid"; then
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
+download_mapped_secret_files() {
+  local destination_dir="$1"
+  local filename_mode="${2:-env}"
+  local parallelism="${KEY_VAULT_DOWNLOAD_PARALLELISM:-8}"
+  if [[ "$filename_mode" != 'env' && "$filename_mode" != 'vault' ]]; then
+    echo "download filename mode must be env or vault" >&2
+    return 64
+  fi
+  if [[ ! "$parallelism" =~ ^[1-9][0-9]*$ ]]; then
+    echo "KEY_VAULT_DOWNLOAD_PARALLELISM must be a positive integer" >&2
+    return 64
+  fi
+
+  mkdir -p "$destination_dir"
+  chmod 700 "$destination_dir"
+  load_key_vault_secret_names
+
+  local pair vault_name env_name filename file
+  local -a download_pids=()
+  for pair in "${SECRET_MAP[@]}"; do
+    vault_name="${pair%%:*}"
+    env_name="${pair#*:}"
+    if ! secret_exists "$vault_name"; then
+      continue
+    fi
+
+    if [[ "$filename_mode" == 'env' ]]; then
+      filename="$env_name"
+    else
+      filename="$vault_name"
+    fi
+    file="$destination_dir/$filename"
+    (
+      if ! az keyvault secret download \
+        --vault-name "$AZURE_KEY_VAULT_NAME" \
+        --name "$vault_name" \
+        --file "$file" \
+        --encoding utf-8 \
+        --output none \
+        --only-show-errors; then
+        echo "::error::Failed to download mapped Key Vault secret: $vault_name"
+        exit 1
+      fi
+      chmod 600 "$file"
+    ) &
+    download_pids+=("$!")
+
+    if (( ${#download_pids[@]} >= parallelism )); then
+      if ! wait_for_secret_downloads "${download_pids[@]}"; then
+        return 1
+      fi
+      download_pids=()
+    fi
+  done
+
+  if (( ${#download_pids[@]} > 0 )); then
+    if ! wait_for_secret_downloads "${download_pids[@]}"; then
+      return 1
+    fi
+  fi
+}
+
 download_kubernetes_secret() {
   : "${AKS_NAMESPACE:?AKS_NAMESPACE is required}"
   local work_dir="$1"
   local secret_dir="$work_dir/kubernetes"
   mkdir -p "$secret_dir"
   chmod 700 "$secret_dir"
-
-  local pair vault_name env_name file
-  for pair in "${SECRET_MAP[@]}"; do
-    vault_name="${pair%%:*}"
-    env_name="${pair#*:}"
-    if secret_exists "$vault_name"; then
-      file="$secret_dir/$env_name"
-      az keyvault secret download \
-        --vault-name "$AZURE_KEY_VAULT_NAME" \
-        --name "$vault_name" \
-        --file "$file" \
-        --encoding utf-8 \
-        --output none \
-        --only-show-errors
-      chmod 600 "$file"
-    fi
-  done
+  download_mapped_secret_files "$secret_dir" env
 
   local required=(
     JWT_SECRET ANON_KEY SERVICE_ROLE_KEY SUPABASE_PUBLISHABLE_KEY

--- a/deploy/scripts/key-vault-secrets.test.sh
+++ b/deploy/scripts/key-vault-secrets.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+cat > "$test_dir/bin/az" <<'MOCK_AZ'
+#!/usr/bin/env bash
+set -euo pipefail
+
+operation="${1:-} ${2:-} ${3:-}"
+case "$operation" in
+  'keyvault secret list')
+    calls=0
+    [[ -f "$MOCK_AZ_LIST_CALLS" ]] && calls="$(<"$MOCK_AZ_LIST_CALLS")"
+    printf '%s' "$((calls + 1))" > "$MOCK_AZ_LIST_CALLS"
+    printf '%s\n' jwt-secret openai-api-key smtp-host
+    ;;
+  'keyvault secret download')
+    name=''
+    file=''
+    while (( $# > 0 )); do
+      case "$1" in
+        --name)
+          name="$2"
+          shift 2
+          ;;
+        --file)
+          file="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [[ "${MOCK_AZ_FAIL_NAME:-}" == "$name" ]]; then
+      exit 1
+    fi
+    printf 'value-for-%s' "$name" > "$file"
+    ;;
+  *)
+    echo "Unexpected az invocation: $operation" >&2
+    exit 64
+    ;;
+esac
+MOCK_AZ
+chmod 755 "$test_dir/bin/az"
+
+export PATH="$test_dir/bin:$PATH"
+export MOCK_AZ_LIST_CALLS="$test_dir/list-calls"
+export AZURE_KEY_VAULT_NAME='test-vault'
+export KEY_VAULT_DOWNLOAD_PARALLELISM=2
+
+# shellcheck source=key-vault-secrets.sh
+source "$repo_root/deploy/scripts/key-vault-secrets.sh"
+
+secret_exists jwt-secret
+secret_exists openai-api-key
+if secret_exists missing-secret; then
+  echo 'secret_exists accepted a missing name' >&2
+  exit 1
+fi
+[[ "$(<"$MOCK_AZ_LIST_CALLS")" == '1' ]]
+
+download_mapped_secret_files "$test_dir/by-env" env
+[[ "$(<"$test_dir/by-env/JWT_SECRET")" == 'value-for-jwt-secret' ]]
+[[ "$(<"$test_dir/by-env/OPENAI_API_KEY")" == 'value-for-openai-api-key' ]]
+[[ "$(<"$test_dir/by-env/SMTP_HOST")" == 'value-for-smtp-host' ]]
+[[ "$(stat --format '%a' "$test_dir/by-env/JWT_SECRET")" == '600' ]]
+
+download_mapped_secret_files "$test_dir/by-vault" vault
+[[ "$(<"$test_dir/by-vault/jwt-secret")" == 'value-for-jwt-secret' ]]
+[[ "$(<"$MOCK_AZ_LIST_CALLS")" == '1' ]]
+
+export MOCK_AZ_FAIL_NAME='openai-api-key'
+if download_mapped_secret_files "$test_dir/failed-download" env \
+  > "$test_dir/expected-download-error" 2>&1; then
+  echo 'download_mapped_secret_files ignored a failed Azure download' >&2
+  exit 1
+fi
+grep --fixed-strings --quiet \
+  'Failed to download mapped Key Vault secret: openai-api-key' \
+  "$test_dir/expected-download-error"
+unset MOCK_AZ_FAIL_NAME
+
+echo 'Key Vault secret cache and parallel downloads passed.'

--- a/deploy/scripts/publish-key-vault-to-vaultwarden.sh
+++ b/deploy/scripts/publish-key-vault-to-vaultwarden.sh
@@ -32,33 +32,18 @@ item_file="$work_dir/item.json"
 bw get item "$BW_ITEM_ID" --session "$BW_SESSION" > "$item_file"
 chmod 600 "$item_file"
 
-vault_names_file="$work_dir/key-vault-secret-names"
-az keyvault secret list \
-  --vault-name "$AZURE_KEY_VAULT_NAME" \
-  --query '[].name' \
-  --output tsv \
-  --only-show-errors > "$vault_names_file"
-chmod 600 "$vault_names_file"
+download_mapped_secret_files "$work_dir" vault
 
 published=0
 for pair in "${SECRET_MAP[@]}"; do
   vault_name="${pair%%:*}"
   field_name="${pair#*:}"
-  if ! grep --fixed-strings --line-regexp --quiet "$vault_name" "$vault_names_file"; then
+  value_file="$work_dir/$vault_name"
+  if [[ ! -s "$value_file" ]]; then
     continue
   fi
 
-  value_file="$work_dir/$vault_name"
   next_item_file="$work_dir/item.next.json"
-  az keyvault secret download \
-    --vault-name "$AZURE_KEY_VAULT_NAME" \
-    --name "$vault_name" \
-    --file "$value_file" \
-    --encoding utf-8 \
-    --output none \
-    --only-show-errors
-  chmod 600 "$value_file"
-
   jq \
     --arg field_name "$field_name" \
     --rawfile field_value "$value_file" \

--- a/supabase/backup/Dockerfile.dockerignore
+++ b/supabase/backup/Dockerfile.dockerignore
@@ -1,2 +1,4 @@
-*
+**
+!supabase/
+!supabase/backup/
 !supabase/backup/run.sh

--- a/supabase/migrator/Dockerfile.dockerignore
+++ b/supabase/migrator/Dockerfile.dockerignore
@@ -1,5 +1,8 @@
-*
+**
+!supabase/
 !supabase/config.toml
+!supabase/migrations/
 !supabase/migrations/**
 !supabase/seed.stage.sql
+!supabase/migrator/
 !supabase/migrator/run.sh


### PR DESCRIPTION
## Resumen

- evita builds y despliegues que no corresponden al tipo de cambio y convierte el frontend productivo en un workflow reutilizable coordinado con AKS
- añade cachés BuildKit por imagen y Deno, elimina el build Docker duplicado en `main` y paraleliza lint/typecheck
- reduce llamadas seriales a Key Vault y conserva la publicación atómica y manual a Vaultwarden
- permite únicamente `/favicon/manifest.json` sin Basic Auth para evitar el 401 de Studio; el resto del Dashboard sigue protegido
- corrige el target `hosted-qa` en el comentario de previews
- deja la exportación histórica de Supabase como acción exclusivamente manual

## Validación

- 176 tests de Edge Functions
- 147 tests frontend y 14 tests API
- lint, typecheck, design spacing y build Vite
- actionlint + ShellCheck para todos los workflows
- Helm lint/template con el chart y sus dependencias
- builds Docker de migrator y backup con contextos mínimos
- prueba de caché, permisos, paralelismo y fallo parcial de Key Vault
- Envoy v1.39.0 aceptó el listener dinámico renderizado con `studio-manifest-public`

## Seguridad y despliegue

No agrega infraestructura. En PR sólo valida; el cambio de Envoy se aplica al fusionar mediante el release normal de AKS.
