### PR TITLE
Modernize CI actions and upgrade Bun to 1.4.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+**
+
+!Dockerfile
+!Caddyfile
+!package.json
+!bun.lock
+!index.html
+!vite.config.ts
+!tsconfig.json
+
+!src/
+!src/**
+!public/
+!public/**

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/azure-static-web-apps-production.yml
+++ b/.github/workflows/azure-static-web-apps-production.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ inputs.commit_sha || github.sha }}
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -104,6 +104,8 @@ jobs:
               /^deploy\//,
               /^docker-compose.*\.yml$/,
               /^\.env\.example$/,
+            ]
+            const backendValidationPatterns = [
               /^\.github\/workflows\/(backend-aks|rotate-backend-secrets|publish-backend-secrets-vaultwarden|onboard-portainer-aks)\.yml$/,
             ]
             const frontendPatterns = [
@@ -111,12 +113,13 @@ jobs:
               /^public\//,
               /^api\//,
               /^(index\.html|package\.json|bun\.lock|vite\.config\.ts|tsconfig.*\.json|eslint\.config\.js|prettier\.config\.js|components\.json)$/,
-              /^\.github\/workflows\/azure-static-web-apps-production\.yml$/,
             ]
             const matches = (patterns) =>
               [...paths].some((path) => patterns.some((pattern) => pattern.test(path)))
 
-            const backend = matches(backendPatterns)
+            const backend =
+              matches(backendPatterns) ||
+              (context.eventName === 'pull_request' && matches(backendValidationPatterns))
             const frontend = matches(frontendPatterns)
             core.info(`Changed paths: ${[...paths].join(', ') || '(none)'}`)
             core.setOutput('backend', String(backend))
@@ -154,7 +157,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: deno test --node-modules-dir=none --allow-env --allow-read --allow-sys=umask supabase/functions/tests/unit
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.18.6
 
@@ -181,12 +184,12 @@ jobs:
           test "$(grep --count 'claimName: acad-ia-backend-storage-data-standard-v1' /tmp/acad-ia-backend.yaml)" = 3
           test "$(grep --count 'claimName: acad-ia-backend-supabase-db-standard-v1' /tmp/acad-ia-backend.yaml)" = 1
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         if: github.event_name == 'pull_request'
 
       - name: Validate container builds
         if: github.event_name == 'pull_request'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           push: false
           files: deploy/docker-bake.hcl
@@ -206,7 +209,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -215,10 +218,10 @@ jobs:
       - name: Login to ACR
         run: az acr login --name "${{ vars.ACR_NAME }}"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build and push backend images
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           push: true
           files: deploy/docker-bake.hcl
@@ -327,7 +330,7 @@ jobs:
               "$work_dir/ai-recovery-cron-publishable-key"
           fi
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.18.6
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -15,7 +15,6 @@ on:
       - 'eslint.config.js'
       - 'prettier.config.js'
       - 'components.json'
-      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -38,7 +37,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -57,7 +56,7 @@ jobs:
           touch dist/.nojekyll
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -75,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/onboard-portainer-aks.yml
+++ b/.github/workflows/onboard-portainer-aks.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/publish-backend-secrets-vaultwarden.yml
+++ b/.github/workflows/publish-backend-secrets-vaultwarden.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/rotate-backend-secrets.yml
+++ b/.github/workflows/rotate-backend-secrets.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  workflows:
+    name: GitHub Actions validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate workflows and shell scripts
+        run: >-
+          docker run --rm
+          --volume "$GITHUB_WORKSPACE:/repo"
+          --workdir /repo
+          rhysd/actionlint:1.7.12
+          -color
+
   frontend:
     name: Frontend Bun tests
     runs-on: ubuntu-latest
@@ -42,7 +56,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - uses: supabase/setup-cli@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.4.0 AS builder
 
 WORKDIR /app
 

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
         "@tanstack/eslint-config": "^0.3.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
-        "@types/bun": "^1.3.6",
+        "@types/bun": "^1.4.0",
         "@types/color": "^4.2.1",
         "@types/node": "^22.10.2",
         "@types/react": "^19.2.0",
@@ -721,7 +721,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
 
@@ -923,7 +923,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -51,7 +51,7 @@
     "npm:@tiptap/extensions@^3.27.1": "3.27.3_@tiptap+core@3.27.3__@tiptap+pm@3.27.3_@tiptap+pm@3.27.3",
     "npm:@tiptap/react@^3.27.1": "3.27.3_@tiptap+core@3.27.3__@tiptap+pm@3.27.3_@tiptap+pm@3.27.3_@types+react@19.2.17_@types+react-dom@19.2.3__@types+react@19.2.17_react@19.2.7_react-dom@19.2.7__react@19.2.7_@floating-ui+dom@1.7.6",
     "npm:@tiptap/starter-kit@^3.27.1": "3.27.3",
-    "npm:@types/bun@^1.3.6": "1.3.14",
+    "npm:@types/bun@^1.4.0": "1.4.0",
     "npm:@types/canvas-confetti@^1.9.0": "1.9.0",
     "npm:@types/color@^4.2.1": "4.2.1",
     "npm:@types/node@^22.10.2": "22.20.0",
@@ -2913,8 +2913,8 @@
         "@babel/types"
       ]
     },
-    "@types/bun@1.3.14": {
-      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+    "@types/bun@1.4.0": {
+      "integrity": "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ==",
       "dependencies": [
         "bun-types"
       ]
@@ -3669,8 +3669,8 @@
     "buffers@0.1.1": {
       "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
     },
-    "bun-types@1.3.14": {
-      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+    "bun-types@1.4.0": {
+      "integrity": "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q==",
       "dependencies": [
         "@types/node@22.20.0"
       ]
@@ -8443,7 +8443,7 @@
         "npm:@tiptap/extensions@^3.27.1",
         "npm:@tiptap/react@^3.27.1",
         "npm:@tiptap/starter-kit@^3.27.1",
-        "npm:@types/bun@^1.3.6",
+        "npm:@types/bun@^1.4.0",
         "npm:@types/canvas-confetti@^1.9.0",
         "npm:@types/color@^4.2.1",
         "npm:@types/node@^22.10.2",

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -246,6 +246,14 @@ más reciente. El staging de Azure activa Supabase y compila el frontend en un
 solo job, sin reservar dos runners de forma serial; las operaciones con el
 token de Supabase siguen ejecutándose desde la revisión confiable de `main`.
 
+Los jobs de JavaScript usan Bun 1.4.0 y el Dockerfile del frontend fija la misma
+versión. Los Actions con runtime propio se mantienen en sus generaciones
+actuales basadas en Node 24; cada PR valida todos los workflows con actionlint
+y ShellCheck. Un cambio exclusivo al mecanismo de CI se valida en el PR pero
+no vuelve a desplegar AKS ni GitHub Pages sin cambios en sus artefactos.
+El contexto Docker del frontend usa una lista explícita de archivos de build,
+por lo que no transfiere dependencias, worktrees, secretos ni artefactos locales.
+
 Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.
 No se copia código a un pod o nodo con `scp`: esos sistemas de archivos son

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "acad-ia-2",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.4.0",
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build",
@@ -102,7 +103,7 @@
     "@tanstack/eslint-config": "^0.3.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",
-    "@types/bun": "^1.3.6",
+    "@types/bun": "^1.4.0",
     "@types/color": "^4.2.1",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",


### PR DESCRIPTION
## Resumen
- fija Bun 1.4.0 en package.json, lockfiles, workflows y el builder Docker
- actualiza Actions oficiales a sus generaciones Node 24 actuales
- valida workflows en cada PR con actionlint y ShellCheck
- evita despliegues de AKS o Pages causados únicamente por cambios al mecanismo de CI
- reduce el contexto Docker del frontend de 382.49 MB a 7.64 MB

## Validación
- bun install --frozen-lockfile
- bun run typecheck
- bun run build
- bun run lint (0 errores; 8 advertencias preexistentes)
- 147 pruebas frontend
- 14 pruebas API
- 176 pruebas Deno
- actionlint 1.7.12
- Docker builder y frontend final
- Bun 1.4.0 comprobado dentro del builder
- configuración Caddy válida

No despliega ni reprovisiona infraestructura de Azure.