### PR TITLE
Skip AKS deploys for backend documentation

### DIFF
--- a/.github/workflows/backend-aks.yml
+++ b/.github/workflows/backend-aks.yml
@@ -105,6 +105,9 @@ jobs:
               /^docker-compose.*\.yml$/,
               /^\.env\.example$/,
             ]
+            const backendIgnoredPatterns = [
+              /^deploy\/.*\.md$/,
+            ]
             const backendValidationPatterns = [
               /^\.github\/workflows\/(backend-aks|rotate-backend-secrets|publish-backend-secrets-vaultwarden|onboard-portainer-aks)\.yml$/,
             ]
@@ -116,9 +119,14 @@ jobs:
             ]
             const matches = (patterns) =>
               [...paths].some((path) => patterns.some((pattern) => pattern.test(path)))
+            const matchesBackend = [...paths].some(
+              (path) =>
+                !backendIgnoredPatterns.some((pattern) => pattern.test(path)) &&
+                backendPatterns.some((pattern) => pattern.test(path)),
+            )
 
             const backend =
-              matches(backendPatterns) ||
+              matchesBackend ||
               (context.eventName === 'pull_request' && matches(backendValidationPatterns))
             const frontend = matches(frontendPatterns)
             core.info(`Changed paths: ${[...paths].join(', ') || '(none)'}`)

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -253,6 +253,8 @@ y ShellCheck. Un cambio exclusivo al mecanismo de CI se valida en el PR pero
 no vuelve a desplegar AKS ni GitHub Pages sin cambios en sus artefactos.
 El contexto Docker del frontend usa una lista explícita de archivos de build,
 por lo que no transfiere dependencias, worktrees, secretos ni artefactos locales.
+Los cambios exclusivos a documentación Markdown bajo `deploy/` tampoco cuentan
+como un artefacto de backend desplegable.
 
 Functions usa directamente
 `supabase/edge-runtime:v1.74.3@sha256:c52405002a890ca9fcf77978671c57f3a988e03174afb277f84ac65bc917013c`.


### PR DESCRIPTION
## Resumen
- excluye documentación Markdown bajo deploy/ del clasificador de artefactos backend
- conserva el despliegue para manifiestos, charts, scripts, Functions y demás archivos ejecutables
- evita que documentación o workflows por sí solos activen AKS en main

## Validación
- actionlint 1.7.12
- casos positivos y negativos del clasificador ejecutados con Node
- el run anterior fue cancelado antes de secretos, Functions y helm upgrade