### PR TITLE
Reconcile Supabase preview when a draft becomes ready

### DIFF
--- a/.github/actions/detect-supabase-changes/action.yml
+++ b/.github/actions/detect-supabase-changes/action.yml
@@ -16,6 +16,15 @@ outputs:
   functions:
     description: Whether Edge Function behavior or unit tests changed.
     value: ${{ steps.detect.outputs.functions }}
+  migrations:
+    description: Whether hosted database migrations changed.
+    value: ${{ steps.detect.outputs.migrations }}
+  stage-seed:
+    description: Whether the hosted stage seed changed.
+    value: ${{ steps.detect.outputs.stage-seed }}
+  reconcile:
+    description: Whether migrations, the hosted seed, and Edge Functions must be reconciled together.
+    value: ${{ steps.detect.outputs.reconcile }}
 
 runs:
   using: composite
@@ -30,6 +39,9 @@ runs:
             core.setOutput('changed', 'true')
             core.setOutput('database', 'true')
             core.setOutput('functions', 'true')
+            core.setOutput('migrations', 'true')
+            core.setOutput('stage-seed', 'true')
+            core.setOutput('reconcile', 'true')
             return
           }
 
@@ -55,6 +67,8 @@ runs:
             /^supabase\/config\.toml$/,
             /^supabase\/functions\//,
           ]
+          const migrationPatterns = [/^supabase\/migrations\//]
+          const stageSeedPatterns = [/^supabase\/seed\.stage\.sql$/]
           const deployablePatterns = [
             /^supabase\/config\.toml$/,
             /^supabase\/migrations\//,
@@ -70,10 +84,19 @@ runs:
           const deployable = matching(deployablePatterns)
           const database = matching(databasePatterns)
           const functions = matching(functionPatterns)
+          const migrations = matching(migrationPatterns)
+          const stageSeed = matching(stageSeedPatterns)
+          const reconcile = [...new Set([...migrations, ...stageSeed, ...functions])]
 
           core.info(`Managed Supabase runtime: ${deployable.join(', ') || '(unchanged)'}`)
           core.info(`Database scope: ${database.join(', ') || '(unchanged)'}`)
           core.info(`Edge Functions scope: ${functions.join(', ') || '(unchanged)'}`)
+          core.info(`Migration scope: ${migrations.join(', ') || '(unchanged)'}`)
+          core.info(`Stage seed scope: ${stageSeed.join(', ') || '(unchanged)'}`)
+          core.info(`Ready-for-review reconciliation: ${reconcile.join(', ') || '(not required)'}`)
           core.setOutput('changed', String(deployable.length > 0))
           core.setOutput('database', String(database.length > 0))
           core.setOutput('functions', String(functions.length > 0))
+          core.setOutput('migrations', String(migrations.length > 0))
+          core.setOutput('stage-seed', String(stageSeed.length > 0))
+          core.setOutput('reconcile', String(reconcile.length > 0))

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -225,7 +225,10 @@ jobs:
 
           : "${SUPABASE_URL:?Supabase preview API URL was not resolved}"
           : "${SUPABASE_PREVIEW_PROJECT_REF:?Supabase preview project ref was not selected}"
-          preview_database_url="${POSTGRES_URL_NON_POOLING:-${POSTGRES_URL:-}}"
+          # GitHub-hosted runners are IPv4-only. Prefer the pooler URL and force
+          # Supavisor session mode, which supports native migration commands.
+          preview_database_url="${POSTGRES_URL:-${POSTGRES_URL_NON_POOLING:-}}"
+          preview_database_url="${preview_database_url/:6543/:5432}"
           resolved_project_ref="${SUPABASE_URL#https://}"
           resolved_project_ref="${resolved_project_ref%%.*}"
           : "${preview_database_url:?Supabase preview database URL was not resolved}"

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -81,9 +81,6 @@ jobs:
         with:
           bun-version: 1.4.0
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Use hosted QA Supabase
         id: hosted_qa_supabase
         if: steps.supabase-changes.outputs.changed != 'true'
@@ -187,6 +184,60 @@ jobs:
 
           bash "$RUNNER_TEMP/sync-hosted-function-secrets.sh" \
             "$SUPABASE_PREVIEW_PROJECT_REF" "$AZURE_PREVIEW_URL"
+
+      # A draft preview is paused while synchronize events keep advancing the
+      # PR. Reconcile the accumulated Supabase changes after it becomes active.
+      - name: Reconcile Supabase preview after draft
+        if: >-
+          github.event.action == 'ready_for_review' &&
+          steps.supabase-target.outputs.available == 'true' &&
+          steps.supabase-target.outputs.source == 'preview' &&
+          steps.supabase-changes.outputs.reconcile == 'true'
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PARENT_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branch_environment="$(mktemp)"
+          trap 'rm -f "$branch_environment"' EXIT
+
+          supabase branches get "$BRANCH_NAME" \
+            --project-ref "$PARENT_PROJECT_REF" \
+            --output env > "$branch_environment"
+          set -a
+          # shellcheck disable=SC1090
+          source "$branch_environment"
+          set +a
+
+          : "${SUPABASE_URL:?Supabase preview API URL was not resolved}"
+          : "${SUPABASE_PREVIEW_PROJECT_REF:?Supabase preview project ref was not selected}"
+          preview_database_url="${POSTGRES_URL_NON_POOLING:-${POSTGRES_URL:-}}"
+          resolved_project_ref="${SUPABASE_URL#https://}"
+          resolved_project_ref="${resolved_project_ref%%.*}"
+          : "${preview_database_url:?Supabase preview database URL was not resolved}"
+          if [[ "$resolved_project_ref" != "$SUPABASE_PREVIEW_PROJECT_REF" ]]; then
+            echo '::error::Las credenciales resueltas no pertenecen a la branch preview seleccionada.'
+            exit 1
+          fi
+          echo "::add-mask::$preview_database_url"
+
+          supabase db push \
+            --db-url "$preview_database_url" \
+            --include-all \
+            --yes
+          psql "$preview_database_url" \
+            --no-psqlrc \
+            --set ON_ERROR_STOP=1 \
+            --file supabase/seed.stage.sql
+          supabase functions deploy \
+            --project-ref "$SUPABASE_PREVIEW_PROJECT_REF" \
+            --use-api
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build preview
         if: steps.supabase-target.outputs.available == 'true'

--- a/.github/workflows/azure-static-web-apps-preview.yml
+++ b/.github/workflows/azure-static-web-apps-preview.yml
@@ -187,12 +187,23 @@ jobs:
 
       # A draft preview is paused while synchronize events keep advancing the
       # PR. Reconcile the accumulated Supabase changes after it becomes active.
+      # The database/functions fallback keeps the rollout compatible with the
+      # trusted detector checked out from a base revision without `reconcile`.
       - name: Reconcile Supabase preview after draft
         if: >-
           github.event.action == 'ready_for_review' &&
           steps.supabase-target.outputs.available == 'true' &&
           steps.supabase-target.outputs.source == 'preview' &&
-          steps.supabase-changes.outputs.reconcile == 'true'
+          (
+            steps.supabase-changes.outputs.reconcile == 'true' ||
+            (
+              steps.supabase-changes.outputs.reconcile == '' &&
+              (
+                steps.supabase-changes.outputs.database == 'true' ||
+                steps.supabase-changes.outputs.functions == 'true'
+              )
+            )
+          )
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
           PARENT_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}

--- a/supabase/seed.stage.sql
+++ b/supabase/seed.stage.sql
@@ -1073,6 +1073,15 @@ INSERT INTO public.carreras (
   ('991edcde-b77e-4d22-b76b-3bf6ec3d3555', 'd17b19c6-b7ab-4bdc-8bb9-ddf6f9e0358e', 'Químico Farmacéutico Biólogo', 'QFB', NULL, true, 'Licenciatura')
 ON CONFLICT (id) DO NOTHING;
 
+-- La estructura canónica se publica al final de esta misma transacción. Si ya
+-- existía publicada, retirarla temporalmente permite que sus parches y la
+-- estructura de asignatura vuelvan a converger sin desactivar los guards de
+-- inmutabilidad. Un fallo revierte también esta transición.
+UPDATE public.estructuras_plan
+SET estado_publicacion = 'ARCHIVADA'
+WHERE id = '69fb2b77-5a95-47e0-bf1f-389d384200e4'
+  AND estado_publicacion = 'PUBLICADA';
+
 INSERT INTO public.estructuras_plan (
   id,
   nombre,


### PR DESCRIPTION
## Resumen

- Detecta cambios de migraciones, `seed.stage.sql` y Edge Functions que requieren reconciliación.
- Al pasar un PR de draft a listo para revisión, obtiene credenciales efímeras de la branch preview, aplica migraciones pendientes, vuelve a ejecutar la semilla de stage y despliega todas las Edge Functions.
- Mantiene la URL Postgres limitada al paso de reconciliación y valida que corresponda al project ref seleccionado.
- Hace que la estructura curricular canónica de `seed.stage.sql` pueda converger repetidamente dentro de una sola transacción sin desactivar los guards de inmutabilidad.

## Validación

- `bun run test:db` — 535 pruebas aprobadas.
- `bun run test:functions` — 176 pruebas aprobadas.
- `actionlint .github/workflows/azure-static-web-apps-preview.yml`.
- YAML y Prettier de los archivos modificados.
- Dos ejecuciones consecutivas de `seed.stage.sql` con el mismo hash de estado canónico.

Closes #269