### PR TITLE
feat(busqueda): usar Full-text search en catálogos

### DIFF
--- a/scripts/update-types.ts
+++ b/scripts/update-types.ts
@@ -10,10 +10,32 @@ const target = linked ? '--linked' : '--local'
 console.log(`🔄 Generando tipos de Supabase (${target})...`)
 
 try {
-  // Ejecutamos el comando y capturamos la salida como texto
-  const output = linked
-    ? await $`supabase gen types typescript --linked --schema public`.text()
-    : await $`supabase gen types typescript --local --schema public`.text()
+  const result = await (
+    linked
+      ? $`supabase gen types typescript --linked --schema public`
+      : $`supabase gen types typescript --local --schema public`
+  )
+    .nothrow()
+    .quiet()
+  const output = result.stdout.toString()
+
+  // El CLI puede cerrar con código distinto de cero al agotar el tiempo de
+  // telemetría, aun cuando ya emitió el esquema completo. No persistimos una
+  // salida incompleta, pero sí conservamos un esquema verificablemente válido.
+  if (
+    !output.startsWith('export type Json =') ||
+    !output.includes('export const Constants =')
+  ) {
+    throw new Error(
+      `Supabase no generó un esquema válido (código ${result.exitCode}): ${result.stderr.toString().trim()}`,
+    )
+  }
+
+  if (result.exitCode !== 0) {
+    console.warn(
+      `⚠️ Supabase generó el esquema con código ${result.exitCode}; se usó la salida completa emitida por el CLI.`,
+    )
+  }
 
   // Escribimos el archivo directamente con Bun (garantiza UTF-8)
   await Bun.write('src/types/supabase.ts', output)

--- a/src/data/api/plans.api.ts
+++ b/src/data/api/plans.api.ts
@@ -82,14 +82,6 @@ type PlanCatalogRpcRow = {
   total_count: number | string | null
 }
 
-// Helper para limpiar texto (lo movemos fuera para reutilizar o lo dejas en un utils)
-const cleanText = (text: string) => {
-  return text
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-}
-
 const nullableUuidFilter = (value?: UUID) =>
   value && value !== 'todas' && value !== 'todos' ? value : null
 
@@ -249,11 +241,11 @@ export async function plans_list(
 
   // 2. Aplicamos filtros dinámicos
 
-  // SOLUCIÓN SEARCH: Limpiamos el input y buscamos en la columna generada
   if (filters.search?.trim()) {
-    const cleanTerm = cleanText(filters.search.trim())
-    // Usamos la columna nueva creada en el Paso 1
-    q = q.ilike('nombre_search', `%${cleanTerm}%`)
+    q = q.textSearch('search_vector', filters.search.trim(), {
+      config: 'public.es_simple_unaccent',
+      type: 'websearch',
+    })
   }
 
   if (filters.carreraId && filters.carreraId !== 'todas') {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -20,7 +20,8 @@ export type Database = {
           id: string
           message_id: string | null
           message_type:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode: string
           request_id: string
           retrieval_query: string | null
@@ -37,7 +38,8 @@ export type Database = {
           id?: string
           message_id?: string | null
           message_type?:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode: string
           request_id: string
           retrieval_query?: string | null
@@ -54,7 +56,8 @@ export type Database = {
           id?: string
           message_id?: string | null
           message_type?:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode?: string
           request_id?: string
           retrieval_query?: string | null
@@ -2381,7 +2384,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Insert: {
           confianza?: number | null
@@ -2392,7 +2396,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado?:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Update: {
           confianza?: number | null
@@ -2403,7 +2408,8 @@ export type Database = {
           importacion_id?: string
           rol?: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado?:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Relationships: [
           {
@@ -2434,10 +2440,10 @@ export type Database = {
           error_codigo: string | null
           error_mensaje: string | null
           estado: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio: string | null
           estructura_destino_id: string | null
           estructura_detectada_id: string | null
           evidencia: Json
+          fecha_inicio_redisenio: string | null
           id: string
           incidencias: Json
           plan_destino_id: string | null
@@ -2457,10 +2463,10 @@ export type Database = {
           error_codigo?: string | null
           error_mensaje?: string | null
           estado?: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio?: string | null
           estructura_destino_id?: string | null
           estructura_detectada_id?: string | null
           evidencia?: Json
+          fecha_inicio_redisenio?: string | null
           id?: string
           incidencias?: Json
           plan_destino_id?: string | null
@@ -2480,10 +2486,10 @@ export type Database = {
           error_codigo?: string | null
           error_mensaje?: string | null
           estado?: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio?: string | null
           estructura_destino_id?: string | null
           estructura_detectada_id?: string | null
           evidencia?: Json
+          fecha_inicio_redisenio?: string | null
           id?: string
           incidencias?: Json
           plan_destino_id?: string | null
@@ -2772,9 +2778,7 @@ export type Database = {
           id: string
           intento_generacion_activo_id: string | null
           openai_response_id: string | null
-          requested_types: Array<
-            Database['public']['Enums']['learning_object_tipo']
-          >
+          requested_types: Array<Database['public']['Enums']['learning_object_tipo']>
           resultado_json: Json
           scope: Database['public']['Enums']['learning_generation_scope']
           tema_id: string | null
@@ -2792,9 +2796,7 @@ export type Database = {
           id?: string
           intento_generacion_activo_id?: string | null
           openai_response_id?: string | null
-          requested_types: Array<
-            Database['public']['Enums']['learning_object_tipo']
-          >
+          requested_types: Array<Database['public']['Enums']['learning_object_tipo']>
           resultado_json?: Json
           scope?: Database['public']['Enums']['learning_generation_scope']
           tema_id?: string | null
@@ -2812,9 +2814,7 @@ export type Database = {
           id?: string
           intento_generacion_activo_id?: string | null
           openai_response_id?: string | null
-          requested_types?: Array<
-            Database['public']['Enums']['learning_object_tipo']
-          >
+          requested_types?: Array<Database['public']['Enums']['learning_object_tipo']>
           resultado_json?: Json
           scope?: Database['public']['Enums']['learning_generation_scope']
           tema_id?: string | null
@@ -3526,6 +3526,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -3556,6 +3557,7 @@ export type Database = {
           plan_hash?: string | null
           plan_origen_id?: string | null
           rol_version_plan?: Database['public']['Enums']['rol_version_plan']
+          search_vector?: unknown
           seleccion_estructura?: string
           semanas_por_ciclo?: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -3586,6 +3588,7 @@ export type Database = {
           plan_hash?: string | null
           plan_origen_id?: string | null
           rol_version_plan?: Database['public']['Enums']['rol_version_plan']
+          search_vector?: unknown
           seleccion_estructura?: string
           semanas_por_ciclo?: number | null
           tipo_ciclo?: Database['public']['Enums']['tipo_ciclo']
@@ -4157,7 +4160,8 @@ export type Database = {
           id: string
           rol_permitido_id: string
           tipo_estructura:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Insert: {
           creado_en?: string
@@ -4166,7 +4170,8 @@ export type Database = {
           id?: string
           rol_permitido_id: string
           tipo_estructura?:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Update: {
           creado_en?: string
@@ -4175,7 +4180,8 @@ export type Database = {
           id?: string
           rol_permitido_id?: string
           tipo_estructura?:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Relationships: [
           {
@@ -4471,7 +4477,8 @@ export type Database = {
           autoridad: string | null
           carrera_id: string | null
           carrera_nivel:
-            Database['public']['Enums']['nivel_plan_estudio'] | null
+            | Database['public']['Enums']['nivel_plan_estudio']
+            | null
           carrera_nombre: string | null
           carrera_nombre_corto: string | null
           clave_sep: string | null
@@ -4606,6 +4613,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -4632,7 +4640,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         SetofOptions: {
           from: '*'
@@ -4790,6 +4799,20 @@ export type Database = {
         Args: { p_search: string }
         Returns: unknown
       }
+      buscar_asignaturas_simulacion: {
+        Args: { p_limit?: number; p_search?: string }
+        Returns: Array<{
+          carrera_id: string
+          carrera_nombre: string
+          codigo: string
+          facultad_id: string
+          facultad_nombre: string
+          id: string
+          nombre: string
+          plan_estudio_id: string
+          plan_nombre: string
+        }>
+      }
       cancelar_importacion_academica: {
         Args: { p_importacion_id: string }
         Returns: {
@@ -4803,10 +4826,10 @@ export type Database = {
           error_codigo: string | null
           error_mensaje: string | null
           estado: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio: string | null
           estructura_destino_id: string | null
           estructura_detectada_id: string | null
           evidencia: Json
+          fecha_inicio_redisenio: string | null
           id: string
           incidencias: Json
           plan_destino_id: string | null
@@ -4907,6 +4930,10 @@ export type Database = {
         Args: { p_intento_id: string; p_token_reclamacion: string }
         Returns: boolean
       }
+      construir_tsquery_prefijos: {
+        Args: { p_busqueda: string }
+        Returns: unknown
+      }
       consultar_intento_chat_ia: {
         Args: { p_intento_id: string }
         Returns: Json
@@ -4933,81 +4960,44 @@ export type Database = {
         }
         Returns: Json
       }
-      crear_importacion_academica:
-        | {
-            Args: {
-              p_carrera_id?: string
-              p_estructura_destino_id?: string
-              p_tipo: Database['public']['Enums']['tipo_importacion_academica']
-            }
-            Returns: {
-              actualizado_en: string
-              antecedente_plan_id: string | null
-              carrera_id: string | null
-              completado_en: string | null
-              confianza_estructura: number | null
-              creado_en: string
-              creado_por: string
-              error_codigo: string | null
-              error_mensaje: string | null
-              estado: Database['public']['Enums']['estado_importacion_academica']
-              fecha_inicio_redisenio: string | null
-              estructura_destino_id: string | null
-              estructura_detectada_id: string | null
-              evidencia: Json
-              id: string
-              incidencias: Json
-              plan_destino_id: string | null
-              resultado_normalizado: Json
-              tenant_id: string
-              tipo: Database['public']['Enums']['tipo_importacion_academica']
-              version_trabajo_plan_id: string | null
-            }
-            SetofOptions: {
-              from: '*'
-              to: 'importaciones_academicas'
-              isOneToOne: true
-              isSetofReturn: false
-            }
-          }
-        | {
-            Args: {
-              p_carrera_id?: string
-              p_estructura_destino_id?: string
-              p_fecha_inicio_redisenio?: string
-              p_plan_destino_id?: string
-              p_tipo: Database['public']['Enums']['tipo_importacion_academica']
-            }
-            Returns: {
-              actualizado_en: string
-              antecedente_plan_id: string | null
-              carrera_id: string | null
-              completado_en: string | null
-              confianza_estructura: number | null
-              creado_en: string
-              creado_por: string
-              error_codigo: string | null
-              error_mensaje: string | null
-              estado: Database['public']['Enums']['estado_importacion_academica']
-              fecha_inicio_redisenio: string | null
-              estructura_destino_id: string | null
-              estructura_detectada_id: string | null
-              evidencia: Json
-              id: string
-              incidencias: Json
-              plan_destino_id: string | null
-              resultado_normalizado: Json
-              tenant_id: string
-              tipo: Database['public']['Enums']['tipo_importacion_academica']
-              version_trabajo_plan_id: string | null
-            }
-            SetofOptions: {
-              from: '*'
-              to: 'importaciones_academicas'
-              isOneToOne: true
-              isSetofReturn: false
-            }
-          }
+      crear_importacion_academica: {
+        Args: {
+          p_carrera_id?: string
+          p_estructura_destino_id?: string
+          p_fecha_inicio_redisenio?: string
+          p_plan_destino_id?: string
+          p_tipo: Database['public']['Enums']['tipo_importacion_academica']
+        }
+        Returns: {
+          actualizado_en: string
+          antecedente_plan_id: string | null
+          carrera_id: string | null
+          completado_en: string | null
+          confianza_estructura: number | null
+          creado_en: string
+          creado_por: string
+          error_codigo: string | null
+          error_mensaje: string | null
+          estado: Database['public']['Enums']['estado_importacion_academica']
+          estructura_destino_id: string | null
+          estructura_detectada_id: string | null
+          evidencia: Json
+          fecha_inicio_redisenio: string | null
+          id: string
+          incidencias: Json
+          plan_destino_id: string | null
+          resultado_normalizado: Json
+          tenant_id: string
+          tipo: Database['public']['Enums']['tipo_importacion_academica']
+          version_trabajo_plan_id: string | null
+        }
+        SetofOptions: {
+          from: '*'
+          to: 'importaciones_academicas'
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       crear_paquete_curricular: {
         Args: {
           p_autoridad_normativa?: string
@@ -5110,6 +5100,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -5420,6 +5411,10 @@ export type Database = {
         Args: { p_datos: Json; p_definicion: Json; p_null_invalid?: boolean }
         Returns: Json
       }
+      normalizar_fecha_importacion_documental: {
+        Args: { p_valor: string }
+        Returns: string
+      }
       normalizar_valor_por_propiedad: {
         Args: { p_null_invalid?: boolean; p_prop: Json; p_value: Json }
         Returns: Json
@@ -5473,9 +5468,7 @@ export type Database = {
           id: string
           intento_generacion_activo_id: string | null
           openai_response_id: string | null
-          requested_types: Array<
-            Database['public']['Enums']['learning_object_tipo']
-          >
+          requested_types: Array<Database['public']['Enums']['learning_object_tipo']>
           resultado_json: Json
           scope: Database['public']['Enums']['learning_generation_scope']
           tema_id: string | null
@@ -5496,6 +5489,30 @@ export type Database = {
           p_estado_id?: string
           p_facultad_id?: string
           p_limit?: number
+          p_nivel?: string
+          p_offset?: number
+          p_search?: string
+          p_sort?: string
+          p_tipo_estructura?: Database['public']['Enums']['tipo_estructura_plan']
+        }
+        Returns: Array<{
+          carrera: Json
+          estado_plan: Json
+          estructura_plan: Json
+          facultad: Json
+          plan: Json
+          puede_abrir_detalle: boolean
+          total_count: number
+        }>
+      }
+      planes_catalogo_buscar_versiones: {
+        Args: {
+          p_activo?: boolean
+          p_carrera_id?: string
+          p_estado_id?: string
+          p_facultad_id?: string
+          p_limit?: number
+          p_modo_version?: string
           p_nivel?: string
           p_offset?: number
           p_search?: string
@@ -6114,7 +6131,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         SetofOptions: {
           from: '*'
@@ -6170,7 +6188,10 @@ export type Database = {
         | 'failed'
         | 'deleted'
       estado_publicacion_estructura:
-        'BORRADOR' | 'PUBLICADA' | 'RETIRADA' | 'ARCHIVADA'
+        | 'BORRADOR'
+        | 'PUBLICADA'
+        | 'RETIRADA'
+        | 'ARCHIVADA'
       estado_sesion_carga_documento:
         | 'created'
         | 'uploading'
@@ -6204,7 +6225,11 @@ export type Database = {
       fase_diseno_curricular: 'FUNDAMENTOS' | 'BLOQUES' | 'MAPA'
       fuente_cambio: 'HUMANO' | 'IA'
       learning_generation_estado:
-        'queued' | 'running' | 'needs_review' | 'completed' | 'failed'
+        | 'queued'
+        | 'running'
+        | 'needs_review'
+        | 'completed'
+        | 'failed'
       learning_generation_scope: 'tema' | 'unidad' | 'asignatura'
       learning_object_tipo:
         | 'apunte'
@@ -6230,7 +6255,11 @@ export type Database = {
         | 'profesor'
         | 'lci'
       rol_archivo_importacion:
-        'PLAN' | 'MAPA' | 'PROGRAMA' | 'RESOLUCION' | 'OTRO'
+        | 'PLAN'
+        | 'MAPA'
+        | 'PROGRAMA'
+        | 'RESOLUCION'
+        | 'OTRO'
       rol_responsable_asignatura: 'PROFESOR_RESPONSABLE' | 'COAUTOR' | 'REVISOR'
       rol_version_plan: 'ANTECEDENTE' | 'VERSION_TRABAJO'
       tipo_asignatura: 'OBLIGATORIA' | 'OPTATIVA' | 'TRONCAL' | 'OTRA'
@@ -6264,7 +6293,12 @@ export type Database = {
         | 'IMPORTADO_DOCUMENTAL'
         | 'REDISENO'
       tipo_sujeto_archivo_documental:
-        'user' | 'role' | 'plan' | 'subject' | 'conversation' | 'tenant'
+        | 'user'
+        | 'role'
+        | 'plan'
+        | 'subject'
+        | 'conversation'
+        | 'tenant'
       tipo_trabajo_generacion_ia:
         | 'plan'
         | 'asignatura'
@@ -6297,12 +6331,12 @@ export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6324,12 +6358,13 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6348,12 +6383,13 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6372,12 +6408,13 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    keyof DefaultSchema['Enums'] | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends (DefaultSchemaEnumNameOrOptions extends {
+    | keyof DefaultSchema['Enums']
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6390,11 +6427,11 @@ export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-    : never) = never,
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -20,7 +20,8 @@ export type Database = {
           id: string
           message_id: string | null
           message_type:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode: string
           request_id: string
           retrieval_query: string | null
@@ -37,7 +38,8 @@ export type Database = {
           id?: string
           message_id?: string | null
           message_type?:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode: string
           request_id: string
           retrieval_query?: string | null
@@ -54,7 +56,8 @@ export type Database = {
           id?: string
           message_id?: string | null
           message_type?:
-            Database['public']['Enums']['tipo_conversacion_documental'] | null
+            | Database['public']['Enums']['tipo_conversacion_documental']
+            | null
           mode?: string
           request_id?: string
           retrieval_query?: string | null
@@ -2381,7 +2384,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Insert: {
           confianza?: number | null
@@ -2392,7 +2396,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado?:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Update: {
           confianza?: number | null
@@ -2403,7 +2408,8 @@ export type Database = {
           importacion_id?: string
           rol?: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado?:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         Relationships: [
           {
@@ -2434,10 +2440,10 @@ export type Database = {
           error_codigo: string | null
           error_mensaje: string | null
           estado: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio: string | null
           estructura_destino_id: string | null
           estructura_detectada_id: string | null
           evidencia: Json
+          fecha_inicio_redisenio: string | null
           id: string
           incidencias: Json
           plan_destino_id: string | null
@@ -2457,10 +2463,10 @@ export type Database = {
           error_codigo?: string | null
           error_mensaje?: string | null
           estado?: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio?: string | null
           estructura_destino_id?: string | null
           estructura_detectada_id?: string | null
           evidencia?: Json
+          fecha_inicio_redisenio?: string | null
           id?: string
           incidencias?: Json
           plan_destino_id?: string | null
@@ -2480,10 +2486,10 @@ export type Database = {
           error_codigo?: string | null
           error_mensaje?: string | null
           estado?: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio?: string | null
           estructura_destino_id?: string | null
           estructura_detectada_id?: string | null
           evidencia?: Json
+          fecha_inicio_redisenio?: string | null
           id?: string
           incidencias?: Json
           plan_destino_id?: string | null
@@ -3520,6 +3526,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -3550,6 +3557,7 @@ export type Database = {
           plan_hash?: string | null
           plan_origen_id?: string | null
           rol_version_plan?: Database['public']['Enums']['rol_version_plan']
+          search_vector?: unknown
           seleccion_estructura?: string
           semanas_por_ciclo?: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -3580,6 +3588,7 @@ export type Database = {
           plan_hash?: string | null
           plan_origen_id?: string | null
           rol_version_plan?: Database['public']['Enums']['rol_version_plan']
+          search_vector?: unknown
           seleccion_estructura?: string
           semanas_por_ciclo?: number | null
           tipo_ciclo?: Database['public']['Enums']['tipo_ciclo']
@@ -4151,7 +4160,8 @@ export type Database = {
           id: string
           rol_permitido_id: string
           tipo_estructura:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Insert: {
           creado_en?: string
@@ -4160,7 +4170,8 @@ export type Database = {
           id?: string
           rol_permitido_id: string
           tipo_estructura?:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Update: {
           creado_en?: string
@@ -4169,7 +4180,8 @@ export type Database = {
           id?: string
           rol_permitido_id?: string
           tipo_estructura?:
-            Database['public']['Enums']['tipo_estructura_plan'] | null
+            | Database['public']['Enums']['tipo_estructura_plan']
+            | null
         }
         Relationships: [
           {
@@ -4465,7 +4477,8 @@ export type Database = {
           autoridad: string | null
           carrera_id: string | null
           carrera_nivel:
-            Database['public']['Enums']['nivel_plan_estudio'] | null
+            | Database['public']['Enums']['nivel_plan_estudio']
+            | null
           carrera_nombre: string | null
           carrera_nombre_corto: string | null
           clave_sep: string | null
@@ -4600,6 +4613,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -4626,7 +4640,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         SetofOptions: {
           from: '*'
@@ -4784,6 +4799,20 @@ export type Database = {
         Args: { p_search: string }
         Returns: unknown
       }
+      buscar_asignaturas_simulacion: {
+        Args: { p_limit?: number; p_search?: string }
+        Returns: {
+          carrera_id: string
+          carrera_nombre: string
+          codigo: string
+          facultad_id: string
+          facultad_nombre: string
+          id: string
+          nombre: string
+          plan_estudio_id: string
+          plan_nombre: string
+        }[]
+      }
       cancelar_importacion_academica: {
         Args: { p_importacion_id: string }
         Returns: {
@@ -4797,10 +4826,10 @@ export type Database = {
           error_codigo: string | null
           error_mensaje: string | null
           estado: Database['public']['Enums']['estado_importacion_academica']
-          fecha_inicio_redisenio: string | null
           estructura_destino_id: string | null
           estructura_detectada_id: string | null
           evidencia: Json
+          fecha_inicio_redisenio: string | null
           id: string
           incidencias: Json
           plan_destino_id: string | null
@@ -4901,6 +4930,10 @@ export type Database = {
         Args: { p_intento_id: string; p_token_reclamacion: string }
         Returns: boolean
       }
+      construir_tsquery_prefijos: {
+        Args: { p_busqueda: string }
+        Returns: unknown
+      }
       consultar_intento_chat_ia: {
         Args: { p_intento_id: string }
         Returns: Json
@@ -4927,81 +4960,44 @@ export type Database = {
         }
         Returns: Json
       }
-      crear_importacion_academica:
-        | {
-            Args: {
-              p_carrera_id?: string
-              p_estructura_destino_id?: string
-              p_tipo: Database['public']['Enums']['tipo_importacion_academica']
-            }
-            Returns: {
-              actualizado_en: string
-              antecedente_plan_id: string | null
-              carrera_id: string | null
-              completado_en: string | null
-              confianza_estructura: number | null
-              creado_en: string
-              creado_por: string
-              error_codigo: string | null
-              error_mensaje: string | null
-              estado: Database['public']['Enums']['estado_importacion_academica']
-              fecha_inicio_redisenio: string | null
-              estructura_destino_id: string | null
-              estructura_detectada_id: string | null
-              evidencia: Json
-              id: string
-              incidencias: Json
-              plan_destino_id: string | null
-              resultado_normalizado: Json
-              tenant_id: string
-              tipo: Database['public']['Enums']['tipo_importacion_academica']
-              version_trabajo_plan_id: string | null
-            }
-            SetofOptions: {
-              from: '*'
-              to: 'importaciones_academicas'
-              isOneToOne: true
-              isSetofReturn: false
-            }
-          }
-        | {
-            Args: {
-              p_carrera_id?: string
-              p_estructura_destino_id?: string
-              p_fecha_inicio_redisenio?: string
-              p_plan_destino_id?: string
-              p_tipo: Database['public']['Enums']['tipo_importacion_academica']
-            }
-            Returns: {
-              actualizado_en: string
-              antecedente_plan_id: string | null
-              carrera_id: string | null
-              completado_en: string | null
-              confianza_estructura: number | null
-              creado_en: string
-              creado_por: string
-              error_codigo: string | null
-              error_mensaje: string | null
-              estado: Database['public']['Enums']['estado_importacion_academica']
-              fecha_inicio_redisenio: string | null
-              estructura_destino_id: string | null
-              estructura_detectada_id: string | null
-              evidencia: Json
-              id: string
-              incidencias: Json
-              plan_destino_id: string | null
-              resultado_normalizado: Json
-              tenant_id: string
-              tipo: Database['public']['Enums']['tipo_importacion_academica']
-              version_trabajo_plan_id: string | null
-            }
-            SetofOptions: {
-              from: '*'
-              to: 'importaciones_academicas'
-              isOneToOne: true
-              isSetofReturn: false
-            }
-          }
+      crear_importacion_academica: {
+        Args: {
+          p_carrera_id?: string
+          p_estructura_destino_id?: string
+          p_fecha_inicio_redisenio?: string
+          p_plan_destino_id?: string
+          p_tipo: Database['public']['Enums']['tipo_importacion_academica']
+        }
+        Returns: {
+          actualizado_en: string
+          antecedente_plan_id: string | null
+          carrera_id: string | null
+          completado_en: string | null
+          confianza_estructura: number | null
+          creado_en: string
+          creado_por: string
+          error_codigo: string | null
+          error_mensaje: string | null
+          estado: Database['public']['Enums']['estado_importacion_academica']
+          estructura_destino_id: string | null
+          estructura_detectada_id: string | null
+          evidencia: Json
+          fecha_inicio_redisenio: string | null
+          id: string
+          incidencias: Json
+          plan_destino_id: string | null
+          resultado_normalizado: Json
+          tenant_id: string
+          tipo: Database['public']['Enums']['tipo_importacion_academica']
+          version_trabajo_plan_id: string | null
+        }
+        SetofOptions: {
+          from: '*'
+          to: 'importaciones_academicas'
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       crear_paquete_curricular: {
         Args: {
           p_autoridad_normativa?: string
@@ -5104,6 +5100,7 @@ export type Database = {
           plan_hash: string | null
           plan_origen_id: string | null
           rol_version_plan: Database['public']['Enums']['rol_version_plan']
+          search_vector: unknown
           seleccion_estructura: string
           semanas_por_ciclo: number | null
           tipo_ciclo: Database['public']['Enums']['tipo_ciclo']
@@ -5414,6 +5411,10 @@ export type Database = {
         Args: { p_datos: Json; p_definicion: Json; p_null_invalid?: boolean }
         Returns: Json
       }
+      normalizar_fecha_importacion_documental: {
+        Args: { p_valor: string }
+        Returns: string
+      }
       normalizar_valor_por_propiedad: {
         Args: { p_null_invalid?: boolean; p_prop: Json; p_value: Json }
         Returns: Json
@@ -5488,6 +5489,30 @@ export type Database = {
           p_estado_id?: string
           p_facultad_id?: string
           p_limit?: number
+          p_nivel?: string
+          p_offset?: number
+          p_search?: string
+          p_sort?: string
+          p_tipo_estructura?: Database['public']['Enums']['tipo_estructura_plan']
+        }
+        Returns: {
+          carrera: Json
+          estado_plan: Json
+          estructura_plan: Json
+          facultad: Json
+          plan: Json
+          puede_abrir_detalle: boolean
+          total_count: number
+        }[]
+      }
+      planes_catalogo_buscar_versiones: {
+        Args: {
+          p_activo?: boolean
+          p_carrera_id?: string
+          p_estado_id?: string
+          p_facultad_id?: string
+          p_limit?: number
+          p_modo_version?: string
           p_nivel?: string
           p_offset?: number
           p_search?: string
@@ -6106,7 +6131,8 @@ export type Database = {
           importacion_id: string
           rol: Database['public']['Enums']['rol_archivo_importacion']
           rol_detectado:
-            Database['public']['Enums']['rol_archivo_importacion'] | null
+            | Database['public']['Enums']['rol_archivo_importacion']
+            | null
         }
         SetofOptions: {
           from: '*'
@@ -6162,7 +6188,10 @@ export type Database = {
         | 'failed'
         | 'deleted'
       estado_publicacion_estructura:
-        'BORRADOR' | 'PUBLICADA' | 'RETIRADA' | 'ARCHIVADA'
+        | 'BORRADOR'
+        | 'PUBLICADA'
+        | 'RETIRADA'
+        | 'ARCHIVADA'
       estado_sesion_carga_documento:
         | 'created'
         | 'uploading'
@@ -6196,7 +6225,11 @@ export type Database = {
       fase_diseno_curricular: 'FUNDAMENTOS' | 'BLOQUES' | 'MAPA'
       fuente_cambio: 'HUMANO' | 'IA'
       learning_generation_estado:
-        'queued' | 'running' | 'needs_review' | 'completed' | 'failed'
+        | 'queued'
+        | 'running'
+        | 'needs_review'
+        | 'completed'
+        | 'failed'
       learning_generation_scope: 'tema' | 'unidad' | 'asignatura'
       learning_object_tipo:
         | 'apunte'
@@ -6222,7 +6255,11 @@ export type Database = {
         | 'profesor'
         | 'lci'
       rol_archivo_importacion:
-        'PLAN' | 'MAPA' | 'PROGRAMA' | 'RESOLUCION' | 'OTRO'
+        | 'PLAN'
+        | 'MAPA'
+        | 'PROGRAMA'
+        | 'RESOLUCION'
+        | 'OTRO'
       rol_responsable_asignatura: 'PROFESOR_RESPONSABLE' | 'COAUTOR' | 'REVISOR'
       rol_version_plan: 'ANTECEDENTE' | 'VERSION_TRABAJO'
       tipo_asignatura: 'OBLIGATORIA' | 'OPTATIVA' | 'TRONCAL' | 'OTRA'
@@ -6256,7 +6293,12 @@ export type Database = {
         | 'IMPORTADO_DOCUMENTAL'
         | 'REDISENO'
       tipo_sujeto_archivo_documental:
-        'user' | 'role' | 'plan' | 'subject' | 'conversation' | 'tenant'
+        | 'user'
+        | 'role'
+        | 'plan'
+        | 'subject'
+        | 'conversation'
+        | 'tenant'
       tipo_trabajo_generacion_ia:
         | 'plan'
         | 'asignatura'
@@ -6289,12 +6331,12 @@ export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6316,12 +6358,13 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6340,12 +6383,13 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    keyof DefaultSchema['Tables'] | { schema: keyof DatabaseWithoutInternals },
-  TableName extends (DefaultSchemaTableNameOrOptions extends {
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6364,12 +6408,13 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    keyof DefaultSchema['Enums'] | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends (DefaultSchemaEnumNameOrOptions extends {
+    | keyof DefaultSchema['Enums']
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
-    : never) = never,
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -6382,11 +6427,11 @@ export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-    : never) = never,
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }

--- a/supabase/functions/usuarios/index.ts
+++ b/supabase/functions/usuarios/index.ts
@@ -651,63 +651,20 @@ Deno.serve(async (req: Request): Promise<Response> => {
           Math.min(Number(url.searchParams.get('limit') ?? 20) || 20, 50),
         )
 
-        let query = supabase
-          .from('asignaturas')
-          .select(
-            'id, nombre, codigo, plan_estudio_id, planes_estudio(id, nombre, nombre_propuesto, nombre_display, carrera_id, carreras(id, nombre, nombre_corto, nivel, facultad_id, facultades(id, nombre, nombre_corto, prefijo)))',
-          )
-          .order('nombre', { ascending: true })
-          .limit(limit)
-
-        if (q) {
-          query = query.ilike('nombre', `%${q.replace(/[%_]/g, '')}%`)
-        }
-
-        const { data, error } = await query
+        const { data, error } = await supabase.rpc(
+          'buscar_asignaturas_simulacion',
+          {
+            p_search: q || null,
+            p_limit: limit,
+          },
+        )
 
         if (error) {
           console.log('[usuarios] simulation subjects error:', error.message)
           throw new HttpError(500, error.message, 'DB_ERROR')
         }
 
-        return sendSuccess(
-          (data ?? []).map((row) => {
-            const plan = firstEmbed<{
-              id: string
-              nombre: string | null
-              nombre_propuesto: string | null
-              nombre_display: string | null
-              carrera_id: string | null
-              carreras: unknown
-            }>(row.planes_estudio)
-            const carrera = firstEmbed<{
-              id: string
-              nombre: string | null
-              nombre_corto: string | null
-              nivel: string | null
-              facultad_id: string | null
-              facultades: unknown
-            }>(plan?.carreras)
-            const facultad = firstEmbed<{
-              id: string
-              nombre: string | null
-              nombre_corto: string | null
-              prefijo: string | null
-            }>(carrera?.facultades)
-
-            return {
-              id: row.id,
-              nombre: row.nombre,
-              codigo: row.codigo,
-              plan_estudio_id: plan?.id ?? row.plan_estudio_id ?? null,
-              plan_nombre: formatPlanNombre(plan),
-              carrera_id: carrera?.id ?? plan?.carrera_id ?? null,
-              carrera_nombre: formatCarreraNombre(carrera),
-              facultad_id: facultad?.id ?? carrera?.facultad_id ?? null,
-              facultad_nombre: formatFacultadNombre(facultad),
-            }
-          }),
-        )
+        return sendSuccess(data ?? [])
       }
 
       if (req.method === 'DELETE' && !action) {

--- a/supabase/migrations/20260827163752_add_full_text_search_catalogos.sql
+++ b/supabase/migrations/20260827163752_add_full_text_search_catalogos.sql
@@ -1,0 +1,356 @@
+-- Los catálogos se consultan como typeahead. Centralizamos la construcción de
+-- prefijos para que planes y asignaturas compartan la misma normalización.
+CREATE OR REPLACE FUNCTION public.construir_tsquery_prefijos(
+  p_busqueda text
+) RETURNS tsquery
+    LANGUAGE plpgsql STABLE
+    SET search_path TO 'public', 'private', 'auth', 'extensions', 'pg_temp'
+    AS $$
+declare
+  cleaned text;
+  tokens text[];
+  query_text text;
+begin
+  cleaned := trim(coalesce(p_busqueda, ''));
+
+  if cleaned = '' then
+    return null;
+  end if;
+
+  cleaned := lower(extensions.unaccent(cleaned));
+  cleaned := regexp_replace(cleaned, '[^[:alnum:][:space:]]+', ' ', 'g');
+  cleaned := regexp_replace(cleaned, '[[:space:]]+', ' ', 'g');
+
+  tokens := regexp_split_to_array(cleaned, '[[:space:]]+');
+
+  select string_agg(token || ':*', ' & ')
+  into query_text
+  from unnest(tokens) as token
+  where token <> '';
+
+  if query_text is null or query_text = '' then
+    return null;
+  end if;
+
+  return to_tsquery('public.es_simple_unaccent', query_text);
+end;
+$$;
+
+ALTER FUNCTION public.construir_tsquery_prefijos(text) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.construir_tsquery_prefijos(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.construir_tsquery_prefijos(text)
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.construir_tsquery_prefijos(text) IS
+  'Construye una tsquery por prefijos, insensible a acentos, para los catálogos académicos.';
+
+CREATE OR REPLACE FUNCTION public.build_asignaturas_prefix_tsquery(
+  p_search text
+) RETURNS tsquery
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'private', 'auth', 'extensions', 'pg_temp'
+    AS $$
+  select public.construir_tsquery_prefijos(p_search);
+$$;
+
+ALTER FUNCTION public.build_asignaturas_prefix_tsquery(text) OWNER TO postgres;
+
+ALTER TABLE public.planes_estudio
+  ADD COLUMN search_vector tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector(
+      'public.es_simple_unaccent',
+      coalesce(nombre_display, '')
+    )
+  ) STORED;
+
+CREATE INDEX planes_estudio_search_vector_gin_idx
+  ON public.planes_estudio
+  USING gin (search_vector);
+
+CREATE OR REPLACE FUNCTION public.planes_catalogo_buscar(
+  p_search text DEFAULT NULL::text,
+  p_facultad_id uuid DEFAULT NULL::uuid,
+  p_carrera_id uuid DEFAULT NULL::uuid,
+  p_estado_id uuid DEFAULT NULL::uuid,
+  p_nivel text DEFAULT NULL::text,
+  p_activo boolean DEFAULT NULL::boolean,
+  p_sort text DEFAULT 'creado_desc'::text,
+  p_limit integer DEFAULT 50,
+  p_offset integer DEFAULT 0,
+  p_tipo_estructura public.tipo_estructura_plan DEFAULT NULL::public.tipo_estructura_plan
+) RETURNS TABLE(
+  plan jsonb,
+  carrera jsonb,
+  facultad jsonb,
+  estructura_plan jsonb,
+  estado_plan jsonb,
+  puede_abrir_detalle boolean,
+  total_count bigint
+)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'private', 'auth', 'extensions', 'pg_temp'
+    AS $$
+  with normalized as (
+    select
+      public.construir_tsquery_prefijos(p_search) as search_query,
+      nullif(btrim(coalesce(p_nivel, '')), '') as nivel_term,
+      case
+        when p_sort in (
+          'creado_desc',
+          'actualizado_desc',
+          'nombre_asc',
+          'nombre_desc'
+        ) then p_sort
+        else 'creado_desc'
+      end as sort_term,
+      greatest(0, least(coalesce(p_limit, 50), 100)) as safe_limit,
+      greatest(0, coalesce(p_offset, 0)) as safe_offset
+  ),
+  filtered as (
+    select
+      pe,
+      c,
+      f,
+      eplan,
+      ep,
+      (
+        case
+          when public.authz_simulacion_activa()
+            then private.authz_claim_has_permission('planes.ver')
+          else public.authz_has_permission('planes.ver'::text)
+        end
+        and public.authz_can_access_plan(pe.id)
+      ) as puede_abrir_detalle
+    from public.planes_estudio pe
+    join public.carreras c on c.id = pe.carrera_id
+    join public.facultades f on f.id = c.facultad_id
+    left join public.estructuras_plan eplan on eplan.id = pe.estructura_id
+    left join public.estados_plan ep on ep.id = pe.estado_actual_id
+    cross join normalized n
+    where public.authz_can_list_plan_catalog_for_facultad(c.facultad_id)
+      and (n.search_query is null or pe.search_vector @@ n.search_query)
+      and (p_facultad_id is null or c.facultad_id = p_facultad_id)
+      and (p_carrera_id is null or pe.carrera_id = p_carrera_id)
+      and (p_estado_id is null or pe.estado_actual_id = p_estado_id)
+      and (p_activo is null or pe.activo = p_activo)
+      and (p_tipo_estructura is null or eplan.tipo = p_tipo_estructura)
+      and (
+        n.nivel_term is null
+        or lower(public.unaccent_immutable(c.nivel::text))
+          = lower(public.unaccent_immutable(n.nivel_term))
+      )
+  )
+  select
+    to_jsonb(filtered.pe) as plan,
+    to_jsonb(filtered.c) as carrera,
+    to_jsonb(filtered.f) as facultad,
+    to_jsonb(filtered.eplan) as estructura_plan,
+    to_jsonb(filtered.ep) as estado_plan,
+    filtered.puede_abrir_detalle,
+    count(*) over () as total_count
+  from filtered
+  cross join normalized n
+  order by
+    case when n.sort_term = 'creado_desc'
+      then (filtered.pe).creado_en end desc nulls last,
+    case when n.sort_term = 'actualizado_desc'
+      then (filtered.pe).actualizado_en end desc nulls last,
+    case when n.sort_term = 'nombre_asc'
+      then (filtered.pe).nombre_search end asc nulls last,
+    case when n.sort_term = 'nombre_desc'
+      then (filtered.pe).nombre_search end desc nulls last,
+    (filtered.pe).id asc
+  limit (select safe_limit from normalized)
+  offset (select safe_offset from normalized);
+$$;
+
+ALTER FUNCTION public.planes_catalogo_buscar(
+  text, uuid, uuid, uuid, text, boolean, text, integer, integer,
+  public.tipo_estructura_plan
+) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.planes_catalogo_buscar_versiones(
+  p_search text DEFAULT NULL::text,
+  p_facultad_id uuid DEFAULT NULL::uuid,
+  p_carrera_id uuid DEFAULT NULL::uuid,
+  p_estado_id uuid DEFAULT NULL::uuid,
+  p_nivel text DEFAULT NULL::text,
+  p_activo boolean DEFAULT NULL::boolean,
+  p_sort text DEFAULT 'creado_desc'::text,
+  p_limit integer DEFAULT 50,
+  p_offset integer DEFAULT 0,
+  p_tipo_estructura public.tipo_estructura_plan DEFAULT NULL::public.tipo_estructura_plan,
+  p_modo_version text DEFAULT 'actuales'::text
+) RETURNS TABLE(
+  plan jsonb,
+  carrera jsonb,
+  facultad jsonb,
+  estructura_plan jsonb,
+  estado_plan jsonb,
+  puede_abrir_detalle boolean,
+  total_count bigint
+)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'private', 'auth', 'extensions', 'pg_temp'
+    AS $$
+  with normalized as (
+    select
+      public.construir_tsquery_prefijos(p_search) as search_query,
+      nullif(btrim(coalesce(p_nivel, '')), '') as nivel_term,
+      case
+        when p_sort in (
+          'creado_desc',
+          'actualizado_desc',
+          'nombre_asc',
+          'nombre_desc'
+        ) then p_sort
+        else 'creado_desc'
+      end as sort_term,
+      greatest(0, least(coalesce(p_limit, 50), 100)) as safe_limit,
+      greatest(0, coalesce(p_offset, 0)) as safe_offset,
+      case
+        when p_modo_version in ('actuales', 'antecedentes', 'todos')
+          then p_modo_version
+        else 'actuales'
+      end as version_term
+  ),
+  filtered as (
+    select
+      pe,
+      c,
+      f,
+      eplan,
+      ep,
+      (
+        case
+          when public.authz_simulacion_activa()
+            then private.authz_claim_has_permission('planes.ver')
+          else public.authz_has_permission('planes.ver'::text)
+        end
+        and public.authz_can_access_plan(pe.id)
+      ) as puede_abrir_detalle
+    from public.planes_estudio pe
+    join public.carreras c on c.id = pe.carrera_id
+    join public.facultades f on f.id = c.facultad_id
+    left join public.estructuras_plan eplan on eplan.id = pe.estructura_id
+    left join public.estados_plan ep on ep.id = pe.estado_actual_id
+    cross join normalized n
+    where public.authz_can_list_plan_catalog_for_facultad(c.facultad_id)
+      and (n.search_query is null or pe.search_vector @@ n.search_query)
+      and (p_facultad_id is null or c.facultad_id = p_facultad_id)
+      and (p_carrera_id is null or pe.carrera_id = p_carrera_id)
+      and (p_estado_id is null or pe.estado_actual_id = p_estado_id)
+      and (p_activo is null or pe.activo = p_activo)
+      and (p_tipo_estructura is null or eplan.tipo = p_tipo_estructura)
+      and (
+        n.nivel_term is null
+        or lower(public.unaccent_immutable(c.nivel::text))
+          = lower(public.unaccent_immutable(n.nivel_term))
+      )
+      and (
+        n.version_term = 'todos'
+        or (n.version_term = 'antecedentes'
+          and pe.rol_version_plan = 'ANTECEDENTE')
+        or (n.version_term = 'actuales'
+          and pe.rol_version_plan <> 'ANTECEDENTE')
+      )
+  )
+  select
+    to_jsonb(filtered.pe) as plan,
+    to_jsonb(filtered.c) as carrera,
+    to_jsonb(filtered.f) as facultad,
+    to_jsonb(filtered.eplan) as estructura_plan,
+    to_jsonb(filtered.ep) as estado_plan,
+    filtered.puede_abrir_detalle,
+    count(*) over () as total_count
+  from filtered
+  cross join normalized n
+  order by
+    case when n.sort_term = 'creado_desc'
+      then (filtered.pe).creado_en end desc nulls last,
+    case when n.sort_term = 'actualizado_desc'
+      then (filtered.pe).actualizado_en end desc nulls last,
+    case when n.sort_term = 'nombre_asc'
+      then (filtered.pe).nombre_search end asc nulls last,
+    case when n.sort_term = 'nombre_desc'
+      then (filtered.pe).nombre_search end desc nulls last,
+    (filtered.pe).id asc
+  limit (select safe_limit from normalized)
+  offset (select safe_offset from normalized);
+$$;
+
+ALTER FUNCTION public.planes_catalogo_buscar_versiones(
+  text, uuid, uuid, uuid, text, boolean, text, integer, integer,
+  public.tipo_estructura_plan, text
+) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.buscar_asignaturas_simulacion(
+  p_search text DEFAULT NULL::text,
+  p_limit integer DEFAULT 20
+) RETURNS TABLE(
+  id uuid,
+  nombre text,
+  codigo text,
+  plan_estudio_id uuid,
+  plan_nombre text,
+  carrera_id uuid,
+  carrera_nombre text,
+  facultad_id uuid,
+  facultad_nombre text
+)
+    LANGUAGE sql STABLE
+    SET search_path TO 'public', 'private', 'auth', 'extensions', 'pg_temp'
+    AS $$
+  with normalized as (
+    select
+      public.construir_tsquery_prefijos(p_search) as search_query,
+      greatest(1, least(coalesce(p_limit, 20), 50)) as safe_limit
+  ),
+  resultados as (
+    select
+      a.id,
+      a.nombre,
+      a.codigo,
+      a.plan_estudio_id,
+      pe.nombre_display as plan_nombre,
+      c.id as carrera_id,
+      c.nombre as carrera_nombre,
+      f.id as facultad_id,
+      f.nombre as facultad_nombre,
+      coalesce(ts_rank(a.search_vector, n.search_query), 0)::real as rank
+    from public.asignaturas a
+    join public.planes_estudio pe on pe.id = a.plan_estudio_id
+    join public.carreras c on c.id = pe.carrera_id
+    join public.facultades f on f.id = c.facultad_id
+    cross join normalized n
+    where n.search_query is null or a.search_vector @@ n.search_query
+  )
+  select
+    r.id,
+    r.nombre,
+    r.codigo,
+    r.plan_estudio_id,
+    r.plan_nombre,
+    r.carrera_id,
+    r.carrera_nombre,
+    r.facultad_id,
+    r.facultad_nombre
+  from resultados r
+  cross join normalized n
+  order by
+    case when n.search_query is not null then r.rank end desc nulls last,
+    lower(r.nombre) asc,
+    r.id asc
+  limit (select safe_limit from normalized);
+$$;
+
+ALTER FUNCTION public.buscar_asignaturas_simulacion(text, integer) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.buscar_asignaturas_simulacion(text, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.buscar_asignaturas_simulacion(text, integer)
+  FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.buscar_asignaturas_simulacion(text, integer)
+  TO service_role;
+
+COMMENT ON FUNCTION public.buscar_asignaturas_simulacion(text, integer) IS
+  'Resuelve el typeahead administrativo de asignaturas usando el índice FTS canónico.';

--- a/supabase/tests/database/full_text_search_catalogos.test.sql
+++ b/supabase/tests/database/full_text_search_catalogos.test.sql
@@ -1,0 +1,103 @@
+begin;
+
+select plan(12);
+
+select has_column(
+  'public',
+  'planes_estudio',
+  'search_vector',
+  'planes_estudio mantiene un vector de búsqueda de texto completo'
+);
+
+select col_type_is(
+  'public',
+  'planes_estudio',
+  'search_vector',
+  'tsvector',
+  'el vector de planes usa el tipo tsvector'
+);
+
+select has_index(
+  'public',
+  'planes_estudio',
+  'planes_estudio_search_vector_gin_idx',
+  'el vector de planes tiene un índice GIN'
+);
+
+select has_function(
+  'public',
+  'construir_tsquery_prefijos',
+  array['text'],
+  'la construcción de consultas FTS por prefijos se comparte entre catálogos'
+);
+
+select is(
+  public.construir_tsquery_prefijos('Pedagogía infantil')::text,
+  '''pedagogia'':* & ''infantil'':*',
+  'la consulta de prefijos conserva palabras y elimina acentos'
+);
+
+select is(
+  public.build_asignaturas_prefix_tsquery('Pedagogía infantil')::text,
+  public.construir_tsquery_prefijos('Pedagogía infantil')::text,
+  'asignaturas conserva la semántica de búsqueda tras centralizar el helper'
+);
+
+select ok(
+  position(
+    'pe.search_vector @@ n.search_query'
+    in pg_get_functiondef(
+      'public.planes_catalogo_buscar(text,uuid,uuid,uuid,text,boolean,text,integer,integer,public.tipo_estructura_plan)'::regprocedure
+    )
+  ) > 0,
+  'el catálogo de planes filtra con Full-text search'
+);
+
+select ok(
+  position(
+    'pe.search_vector @@ n.search_query'
+    in pg_get_functiondef(
+      'public.planes_catalogo_buscar_versiones(text,uuid,uuid,uuid,text,boolean,text,integer,integer,public.tipo_estructura_plan,text)'::regprocedure
+    )
+  ) > 0,
+  'el catálogo de planes por versión filtra con Full-text search'
+);
+
+select has_function(
+  'public',
+  'buscar_asignaturas_simulacion',
+  array['text', 'integer'],
+  'el selector de simulación tiene un RPC FTS dedicado'
+);
+
+select ok(
+  position(
+    'a.search_vector @@ n.search_query'
+    in pg_get_functiondef(
+      'public.buscar_asignaturas_simulacion(text,integer)'::regprocedure
+    )
+  ) > 0,
+  'el RPC de simulación consulta el vector FTS de asignaturas'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.buscar_asignaturas_simulacion(text,integer)',
+    'EXECUTE'
+  ),
+  'el RPC de simulación queda disponible para el cliente de servicio'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'public.buscar_asignaturas_simulacion(text,integer)',
+    'EXECUTE'
+  ),
+  'el RPC de simulación no queda expuesto al cliente autenticado'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Resumen

- añade un vector `tsvector` e índice GIN para los planes de estudio;
- migra los dos RPC de catálogo de planes y la ruta alternativa del API a Full-text search;
- reemplaza el selector administrativo de asignaturas por un RPC FTS de acceso exclusivo para `service_role`;
- incorpora contratos pgTAP de FTS y permisos, y regenera los tipos de Supabase.

## Validación

- `bun run test:db`: 547 aserciones pgTAP aprobadas. El CLI luego devuelve un aviso no funcional de cierre de telemetría PostHog.
- `bun run test:functions`: 179 aprobadas.
- `bun run typecheck`
- `bun run lint`: 0 errores (8 advertencias preexistentes en pruebas de documentos).